### PR TITLE
feat(diagram): Drag, Snap, Docking 기본 기능 구현

### DIFF
--- a/.codex/features/docking_guide.md
+++ b/.codex/features/docking_guide.md
@@ -1,0 +1,167 @@
+# Docking Guide
+
+## 목적
+현재 구현된 M2 `T1~T7`의 도킹 로직이 어떤 상태와 함수 흐름으로 동작하는지 설명한다.  
+대상 코드는 다음 두 파일이다.
+
+- `src/features/diagram/lib/docking.ts`
+- `src/features/diagram/ui/CanvasCore/CanvasCoreInner.tsx`
+
+## 핵심 개념
+이번 단계의 목표는 "드래그 중 자유 이동"과 "드롭 시점 스냅 확정"을 분리하는 것이다.
+
+- 드래그 중에는 노드가 자유롭게 움직인다.
+- 드롭하는 순간 nearest dock cell을 계산한다.
+- 유효하지 않은 드롭이면 fallback 체인을 적용한다.
+- 노드마다 자유 좌표와 도킹 상태를 별도로 유지한다.
+
+## 상태 모델
+도킹 상태는 `DockedNodeState`로 관리한다.
+
+- `freePosition`: 드래그 중 실제 자유 좌표
+- `dockedCell`: 현재 확정된 셀
+- `lastValidDock`: 마지막으로 유효했던 셀
+
+이 구조로 인해 "지금 마우스로 이동 중인 위치"와 "최종 도킹 위치"를 구분할 수 있다.
+
+## 도메인 상수와 결과 타입
+`src/features/diagram/lib/docking.ts`에는 도킹 규칙을 표현하는 상수와 타입이 있다.
+
+- `SNAP_IN_DISTANCE`, `SNAP_OUT_DISTANCE`
+  - 현재 단계에서는 상수만 정의되어 있다.
+  - 이후 프리뷰, 히스테리시스 구현에서 사용한다.
+- `DROP_REASONS`
+  - `valid-dock`
+  - `outside-stage`
+  - `occupied-cell`
+  - `no-nearest-cell`
+- `FALLBACK_STRATEGIES`
+  - `last-valid-dock`
+  - `nearest-empty-cell`
+  - `clamp`
+
+드롭 처리 결과는 `position`, `cell`, `reason`, `usedFallback`, `strategy` 조합으로 반환된다.
+
+## 드래그 상태 전이
+이벤트별 상태 변경 규칙은 `transitionDockedNodeState`에 고정되어 있다.
+
+### dragStart
+- `freePosition`만 현재 좌표로 갱신한다.
+- 기존 `dockedCell`, `lastValidDock`는 유지한다.
+
+### dragMove
+- `freePosition`만 드래그 좌표로 갱신한다.
+
+### dragStop
+- 최종 좌표를 `freePosition`에 반영한다.
+- 최종 확정 셀을 `dockedCell`에 반영한다.
+- 확정 셀이 있으면 `lastValidDock`도 갱신한다.
+
+### cancel
+- `lastValidDock` 또는 `dockedCell` 기준 위치로 `freePosition`을 복구한다.
+
+## nearest dock 계산
+`getNearestDockCell(position, stage)`는 좌표에서 가장 가까운 셀을 계산한다.
+
+- 노드 크기(`NODE_SIZE`) 기준으로 셀 인덱스를 계산한다.
+- 경계값 tie-break가 항상 같은 방향으로 처리되도록 `Number.EPSILON`을 사용한다.
+- 계산된 셀이 현재 `stage` 범위 밖이면 `null`을 반환한다.
+
+이 함수는 동일 입력에 대해 동일 출력을 반환해야 한다.
+
+## 도킹 가능 셀 검증
+`isDockableCell(cell, occupancy, stage, ignoreNodeId?)`는 셀이 실제로 사용 가능한지 검사한다.
+
+검사 항목은 두 가지다.
+
+- 현재 `stage` 범위 안인지
+- 다른 노드가 이미 점유 중인지
+
+`ignoreNodeId`를 넘기면 자기 자신은 충돌로 간주하지 않는다.  
+그래서 드래그 중인 노드가 원래 위치한 셀을 occupied로 오판하지 않는다.
+
+## fallback 체인
+유효하지 않은 드롭이면 `applyFallback`이 대체 위치를 결정한다.
+
+우선순위는 다음과 같다.
+
+1. `lastValidDock`
+2. nearest empty cell
+3. clamp position
+
+### 1. lastValidDock
+- 마지막 유효 셀이 아직 비어 있고 stage 안에 있으면 그 셀로 복귀한다.
+
+### 2. nearest empty cell
+- 현재 위치 또는 마지막 유효 셀에 가장 가까운 빈 셀을 찾는다.
+- stage 전체를 순회하면서 가장 작은 거리의 빈 셀을 선택한다.
+
+### 3. clamp position
+- 빈 셀도 찾지 못하면 좌표를 stage 안쪽으로만 보정한다.
+- 이 경우 셀이 아닌 좌표 보정이므로 마지막 안전 장치 역할이다.
+
+반환값에는 `strategy`가 포함되어 어떤 fallback이 선택됐는지 추적할 수 있다.
+
+## drop resolver
+`resolveDropPosition(input)`은 드롭 처리의 단일 진입점이다.
+
+처리 순서는 다음과 같다.
+
+1. 노드가 stage 밖에 있으면 `outside-stage`로 판단하고 fallback 적용
+2. nearest cell이 없으면 `no-nearest-cell`로 판단하고 fallback 적용
+3. nearest cell이 occupied면 `occupied-cell`로 판단하고 fallback 적용
+4. 모두 통과하면 `valid-dock`으로 판단하고 해당 셀 위치로 스냅
+
+UI는 이 함수의 결과를 그대로 반영하면 된다.  
+도킹 규칙을 UI 이벤트 핸들러 안에서 다시 계산하지 않는다.
+
+## CanvasCoreInner에서의 연결 방식
+React Flow 쪽에서는 `nodeDockingState`를 별도로 둬서 노드별 도킹 상태를 저장한다.
+
+- key: 노드 id
+- value: `DockedNodeState`
+
+초기 노드와 새로 추가된 노드는 `createDockedNodeState(position, stage)`로 초기화한다.
+
+## 드래그 이벤트 흐름
+### onNodeDragStart
+- 가이드를 표시한다.
+- `transitionDockedNodeState(..., { type: "dragStart" })` 호출
+- 도킹 상태는 유지하고 자유 좌표만 시작 시점으로 맞춘다.
+
+### onNodeDrag
+- `transitionDockedNodeState(..., { type: "dragMove" })` 호출
+- `freePosition`을 계속 갱신한다.
+- 노드가 현재 stage 밖으로 나가면 기존 M1 규칙대로 stage를 확장한다.
+
+### onNodeDragStop
+- 현재 노드의 `lastValidDock`를 읽는다.
+- `resolveDropPosition(...)`을 호출한다.
+- 반환된 `resolution.position`을 실제 노드 좌표에 반영한다.
+- 같은 결과를 `transitionDockedNodeState(..., { type: "dragStop" })`로 도킹 상태에도 반영한다.
+- 가이드를 숨긴다.
+
+즉, 드롭 시점에만 최종 스냅과 fallback이 적용된다.
+
+## snapToGrid 처리
+React Flow의 기본 `snapToGrid`는 명시적으로 `false`다.
+
+- 드래그 중 React Flow가 자동 스냅하지 않는다.
+- 대신 드롭 시점에만 `resolveDropPosition`이 최종 좌표를 결정한다.
+
+이 설정이 있어야 "자유 드래그 + 드롭 시점 스냅" 요구사항을 만족할 수 있다.
+
+## 현재 단계에서 보장되는 동작
+- 드래그 중 자유 이동
+- 기존 stage 확장 동작 유지
+- 드롭 순간 nearest snap 시도
+- invalid drop이면 fallback 체인 적용
+- 노드별 `freePosition`, `dockedCell`, `lastValidDock` 유지
+
+## 아직 남은 작업
+현재 문서는 `T1~T7` 기준이다. 아직 구현하지 않은 항목은 다음과 같다.
+
+- 스냅 프리뷰 UI
+- 히스테리시스(`snapInDistance`, `snapOutDistance`) 실제 적용
+- invalid drop 이유 및 strategy 노출
+- 테스트 코드

--- a/.codex/plans/002-milestone-drag-snap-docking-tasks.md
+++ b/.codex/plans/002-milestone-drag-snap-docking-tasks.md
@@ -75,7 +75,7 @@
 - T5
 
 완료 기준(DoD)
-- dragStart/dragMove/dragStop/cancel 전이 일관성 확보
+- dragStart/dragMove/dragStop/dragCancel 전이 일관성 확보
 - `lastValidDock` 누락 케이스 없음
 
 ## P1 (Core Interaction)

--- a/.codex/plans/002-milestone-drag-snap-docking-tasks.md
+++ b/.codex/plans/002-milestone-drag-snap-docking-tasks.md
@@ -1,0 +1,181 @@
+# Milestone 2 Task Breakdown (Executable Checklist)
+
+## 사용 방법
+- 각 항목은 독립 PR 단위로 쪼갤 수 있도록 작성했다.
+- 의존성이 있는 항목은 선행 태스크 완료 후 진행한다.
+- 모든 태스크는 "완료 기준(DoD)" 충족 시 완료 처리한다.
+
+## P0 (Foundation)
+
+### T1. 도메인 타입/상수 정의
+- [ ] `snapInDistance`, `snapOutDistance`, fallback strategy enum 상수 정의
+- [ ] drop 판정 결과 타입(`reason`, `usedFallback`, `strategy`) 정의
+- [ ] 기존 grid 타입과 충돌 없는지 타입 정합성 점검
+
+의존성
+- 없음
+
+완료 기준(DoD)
+- 타입 에러 0건
+- 상수/타입이 후속 함수에서 재사용 가능
+
+### T2. 순수 함수: nearest snap 계산
+- [ ] `getNearestDockCell(position, stage)` 구현
+- [ ] stage 경계 내/외 케이스 처리
+- [ ] 동률/경계값 tie-break 규칙 고정
+
+의존성
+- T1
+
+완료 기준(DoD)
+- 동일 입력 -> 동일 출력 보장
+- 경계값 케이스 테스트 통과
+
+### T3. 순수 함수: 도킹 가능성 검증
+- [ ] `isDockableCell(cell, occupancy, stage)` 구현
+- [ ] 점유 셀 충돌 판정
+- [ ] stage 범위 검증
+
+의존성
+- T1
+
+완료 기준(DoD)
+- 점유/비점유/범위 밖 케이스 테스트 통과
+
+### T4. 순수 함수: fallback 체인
+- [ ] `applyFallback(input)` 구현
+- [ ] 우선순위 적용: `lastValidDock -> nearest empty cell -> clamp`
+- [ ] 선택된 전략(`strategy`) 반환
+
+의존성
+- T2, T3
+
+완료 기준(DoD)
+- invalid drop 입력에서 항상 최종 위치 반환
+- 전략 로그가 기대 우선순위와 일치
+
+### T5. 순수 함수: drop 해결기
+- [ ] `resolveDropPosition(input)` 구현
+- [ ] valid drop 시 nearest snap 반영
+- [ ] invalid drop 시 fallback 위임
+
+의존성
+- T2, T3, T4
+
+완료 기준(DoD)
+- 단일 진입점으로 모든 drop 시나리오 처리
+- `reason/usedFallback` 결과가 테스트와 일치
+
+### T6. 상태 모델 도입
+- [ ] 노드 상태에 `freePosition`, `dockedCell`, `lastValidDock` 반영
+- [ ] drag 이벤트별 상태 전이표 문서화
+- [ ] 상태 갱신 책임 분리(UI 이벤트 vs 도메인 함수)
+
+의존성
+- T5
+
+완료 기준(DoD)
+- dragStart/dragMove/dragStop/cancel 전이 일관성 확보
+- `lastValidDock` 누락 케이스 없음
+
+## P1 (Core Interaction)
+
+### T7. 자유 드래그 + 드롭 시점 스냅
+- [ ] 드래그 중 자유 이동 유지 (`snapToGrid` 비활성 유지 확인)
+- [ ] `onNodeDragStop`에서 `resolveDropPosition` 호출
+- [ ] 최종 좌표 반영 및 상태 동기화
+
+의존성
+- T6
+
+완료 기준(DoD)
+- 드롭 순간에만 스냅 적용
+- 기존 M1 stage 확장 동작 회귀 없음
+
+### T8. 스냅 프리뷰 표시
+- [ ] 프리뷰 셀 계산/표시 로직 추가
+- [ ] 프리뷰와 확정 도킹 상태 분리
+- [ ] 빠른 드래그 시 렌더 과다 갱신 최소화
+
+의존성
+- T7
+
+완료 기준(DoD)
+- 프리뷰가 드래그 맥락에 맞게 정확히 표시
+- 드롭 확정 전에는 실제 위치 변경 없음
+
+### T9. 히스테리시스 적용
+- [ ] `snapInDistance` 진입 규칙 구현
+- [ ] `snapOutDistance` 유지/해제 규칙 구현
+- [ ] 경계값 떨림 방지(진입/이탈 분리)
+
+의존성
+- T8
+
+완료 기준(DoD)
+- 경계 부근에서 프리뷰 깜빡임 최소화
+- 임계값 변경 시 동작 예측 가능
+
+## P2 (Recovery/Policy)
+
+### T10. invalid drop 정책 연결
+- [ ] 경계 밖/점유 셀 드롭 시 invalid 처리
+- [ ] `lastValidDock` 롤백 동작 연결
+- [ ] fallback 체인 UI 반영
+
+의존성
+- T9
+
+완료 기준(DoD)
+- invalid drop에서도 최종 위치 미결정 상태 없음
+- 우선순위 정책이 실제 동작과 일치
+
+### T11. 관측성/디버깅 보강
+- [ ] `reason`, `strategy`를 개발용 로그/디버그 패널에 노출(개발 모드)
+- [ ] 주요 실패 케이스 재현용 시나리오 문서화
+
+의존성
+- T10
+
+완료 기준(DoD)
+- 이슈 재현 시 fallback 결정 경로 추적 가능
+
+## 테스트 태스크
+
+### T12. Unit (Vitest)
+- [ ] nearest snap 계산 테스트
+- [ ] occupancy/경계 검증 테스트
+- [ ] fallback 체인 우선순위 테스트
+- [ ] hysteresis 경계값 테스트
+
+의존성
+- T5, T9
+
+완료 기준(DoD)
+- 핵심 순수 함수 분기 커버
+
+### T13. Component (RTL)
+- [ ] drag-stop 시 snap 반영 테스트
+- [ ] 프리뷰 표시/해제 테스트
+- [ ] invalid drop 롤백 테스트
+
+의존성
+- T10
+
+완료 기준(DoD)
+- 주요 사용자 플로우 회귀 방지 가능
+
+### T14. 수동 회귀 점검
+- [ ] M1: stage 확장(4->7->10) 동작 확인
+- [ ] M1: 가이드 표시/숨김 동작 확인
+- [ ] M2: snap/preview/rollback 동작 확인
+
+의존성
+- T13
+
+완료 기준(DoD)
+- 체크리스트 전 항목 통과
+
+## 권장 실행 순서 (PR 단위: 2개)
+1. PR-1: T1~T7 (P0 전부 + P1 핵심 snap + 순수 함수/핵심 경로 Unit)
+2. PR-2: T8~T11, T12~T14 (프리뷰/히스테리시스 + rollback/fallback + 컴포넌트/회귀 검증)

--- a/.codex/plans/002-milestone-drag-snap-docking.md
+++ b/.codex/plans/002-milestone-drag-snap-docking.md
@@ -40,7 +40,7 @@
   - `dockedCell`: 현재 확정 도킹 셀
   - `lastValidDock`: 마지막 유효 도킹 셀
 - 이벤트별 상태 전이 정의
-  - `dragStart`, `dragMove`, `dragStop`, `cancel`
+  - `dragStart`, `dragMove`, `dragStop`, `dragCancel`
 - React Flow 이벤트와 상태 책임 분리(UI 이벤트 -> 도메인 함수 호출 -> 상태 반영)
 
 완료 기준

--- a/.codex/plans/002-milestone-drag-snap-docking.md
+++ b/.codex/plans/002-milestone-drag-snap-docking.md
@@ -1,0 +1,117 @@
+# Milestone 2 Plan (Drag, Snap, Docking)
+
+## 목표
+`roadmap.md`의 **M2. Drag, Snap, Docking** 항목을 우선순위(`P0 -> P1 -> P2`)대로 구현 가능한 상태로 완수한다.
+- `[P0]` 스냅/도킹/검증 도메인 로직 순수 함수 분리
+- `[P0]` `freePosition`, `dockedCell`, `lastValidDock` 상태 흐름 구현
+- `[P1]` 자유 드래그 + 드롭 시 nearest snap
+- `[P1]` 스냅 프리뷰 + 히스테리시스(`snapInDistance`, `snapOutDistance`)
+- `[P2]` invalid drop 롤백 + fallback(`lastValidDock -> nearest empty cell -> clamp`)
+
+## 범위 (In Scope)
+- 드래그 중 자유 이동, 드롭 시점 스냅 확정
+- 도킹 상태 모델 및 전이 규칙
+- 점유 셀/경계 검증과 fallback 정책
+- 스냅 프리뷰 시각화 및 임계거리 기반 유지/해제
+- M2 기준 테스트(Unit 중심 + 핵심 컴포넌트 동작)
+
+## 범위 (Out of Scope)
+- 블록 편집 UX(M4), 검색 API(M5), 저장/협업(M6)
+- 스키마 마이그레이션(M3 잔여 항목)
+
+## 구현 단계
+
+### 1. P0-A 도메인 계약(순수 함수) 고정
+- 함수 시그니처 정의
+  - `getNearestDockCell(position, stage): CellCoord | null`
+  - `isDockableCell(cell, occupancy, stage): boolean`
+  - `resolveDropPosition(input): { nextPosition; reason; usedFallback }`
+  - `applyFallback(input): { position; strategy }`
+- 입력/출력 타입(노드 좌표, 셀, 점유맵, stage) 명시
+- 경계/점유/거리 계산 상수화 (`snapInDistance`, `snapOutDistance` 포함)
+
+완료 기준
+- UI 코드 없이 함수 단독 테스트 가능한 구조
+- fallback 전략 우선순위가 코드로 고정됨
+
+### 2. P0-B 상태 흐름 설계 및 반영
+- 노드별 상태 모델 정의
+  - `freePosition`: 드래그 중 실제 좌표
+  - `dockedCell`: 현재 확정 도킹 셀
+  - `lastValidDock`: 마지막 유효 도킹 셀
+- 이벤트별 상태 전이 정의
+  - `dragStart`, `dragMove`, `dragStop`, `cancel`
+- React Flow 이벤트와 상태 책임 분리(UI 이벤트 -> 도메인 함수 호출 -> 상태 반영)
+
+완료 기준
+- 상태 전이표 기준으로 모든 이벤트가 일관 처리
+- `lastValidDock`가 롤백 기준으로 안정적으로 유지
+
+### 3. P1-A 드롭 시 nearest snap 구현
+- 드래그 중에는 `snapToGrid` 없이 자유 이동 유지
+- `onNodeDragStop`에서 nearest cell 계산 후 스냅 확정
+- 스냅 불가 시 즉시 fallback 진입 없이 "검증 결과" 먼저 확보
+
+완료 기준
+- 드롭 순간에만 위치가 스냅됨
+- nearest snap 결과가 항상 재현 가능(동일 입력 -> 동일 결과)
+
+### 4. P1-B 스냅 프리뷰 + 히스테리시스
+- 프리뷰 셀 표시 규칙 정의
+  - 진입: `distance <= snapInDistance`
+  - 유지/해제: `distance >= snapOutDistance`
+- 프리뷰와 최종 확정 분리(프리뷰는 힌트, 확정은 drop 시 결정)
+- 빠른 드래그/경계 인접 상황에서 프리뷰 깜빡임 최소화
+
+완료 기준
+- 프리뷰가 경계값에서 튀지 않고 안정적으로 표시
+- 사용자가 드롭 전에 스냅 의도를 시각적으로 인지 가능
+
+### 5. P2 invalid drop 롤백 + fallback 완성
+- invalid 조건
+  - stage 경계 밖
+  - 점유 셀 충돌
+- fallback 체인 적용
+  1. `lastValidDock`
+  2. nearest empty cell
+  3. clamp position
+- 각 결과에 `reason/strategy` 기록(디버깅/테스트 용)
+
+완료 기준
+- 무효 드롭에서도 노드 위치가 항상 결정됨(불확정 상태 없음)
+- 정책 순서대로 fallback이 적용됨
+
+### 6. 안정화 및 검증
+- Unit(Vitest)
+  - nearest snap, hysteresis 경계값, occupancy 충돌, fallback 체인
+- Component(RTL)
+  - drag-stop 스냅, 프리뷰 표시/해제, invalid drop 롤백
+- 수동 시나리오
+  - stage 확장과 M2 동작 동시 검증(회귀 확인)
+
+완료 기준
+- M2 체크리스트 전 항목 통과
+- 기존 M1 동작(확장/가이드/연결) 회귀 없음
+
+## 산출물
+- M2 도메인 순수 함수 모듈(스냅/도킹/검증/fallback)
+- 노드 도킹 상태 흐름(`freePosition`, `dockedCell`, `lastValidDock`)
+- 드롭 시 nearest snap + 프리뷰/히스테리시스 UX
+- invalid drop 롤백 정책 완성 및 테스트 세트
+
+## 검증 체크리스트 (M2 기준)
+- [ ] 순수 함수 기반으로 스냅/도킹/검증 로직이 분리됐다.
+- [ ] `freePosition`, `dockedCell`, `lastValidDock` 상태 흐름이 동작한다.
+- [ ] 자유 드래그 후 드롭 시 nearest snap이 적용된다.
+- [ ] 스냅 프리뷰와 히스테리시스가 안정적으로 동작한다.
+- [ ] invalid drop 시 fallback 우선순위대로 롤백된다.
+
+## 리스크와 대응
+- 리스크: UI 이벤트 핸들러에 도메인 로직이 다시 섞일 가능성
+- 대응: 이벤트 핸들러는 "입력 수집/결과 반영"만 수행하도록 규칙화
+
+- 리스크: 히스테리시스 임계값 튜닝 실패로 프리뷰 떨림 발생
+- 대응: 임계값 상수 분리 + 경계값 테스트 케이스 고정
+
+- 리스크: fallback 체인에서 예외 분기 누락
+- 대응: `resolveDropPosition` 단일 진입점 강제 + reason 코드 기반 테스트

--- a/.codex/roadmap.md
+++ b/.codex/roadmap.md
@@ -15,16 +15,16 @@
 - [x] 드래그 시작/종료에 따른 그리드 가이드 표시/숨김 처리
 
 ### M2. Drag, Snap, Docking
-- [ ] 자유 드래그 이동 + 근접 셀 탐색 구현
-- [ ] 스냅 프리뷰 및 히스테리시스(`snapInDistance`, `snapOutDistance`) 구현
-- [ ] 드롭은 어디서든 허용하되, 가장 가까운 그리드 내부 도킹 확정
-- [ ] 그리드 밖/점유 셀 드롭 시 `lastValidDock` 롤백 및 fallback 정책 구현
+- [ ] `[P0]` 스냅/도킹/검증 도메인 로직을 순수 함수로 분리
+- [ ] `[P0]` `freePosition`, `dockedCell`, `lastValidDock` 상태 흐름 구현
+- [ ] `[P1]` 자유 드래그 이동 + 드롭 시 nearest snap
+- [ ] `[P1]` 스냅 프리뷰 및 히스테리시스(`snapInDistance`, `snapOutDistance`) 구현
+- [ ] `[P2]` 그리드 밖/점유 셀 드롭 시 `lastValidDock` 롤백 및 fallback 정책 구현
+  - fallback 우선순위: `lastValidDock -> nearest empty cell -> clamp`
 
 ### M3. Data Model and Domain Rules
 - [ ] `NodeItem`/`GridState`/`EdgeItem` 타입 정의 및 정규화
-- [ ] `freePosition`, `dockedCell`, `lastValidDock` 상태 흐름 구현
 - [ ] 캔버스 직렬화 스키마 버전 도입 및 마이그레이션 훅 구성
-- [ ] 스냅/도킹/검증 도메인 로직을 순수 함수로 분리
 
 ### M4. Block System
 - [ ] 블록 생성 플로우(메뉴에서 타입 선택 후 노드 생성) 구현

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"@rsbuild/core": "^1.2.4",
 		"@rsbuild/plugin-babel": "^1.1.1",
 		"@rsbuild/plugin-react": "^1.1.0",
+		"@rstest/core": "^0.9.0",
 		"@tanstack/router-plugin": "^1.164.0",
 		"@types/react": "^19.0.8",
 		"@types/react-dom": "^19.0.3",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,15 @@
 		"@rsbuild/core": "^1.2.4",
 		"@rsbuild/plugin-babel": "^1.1.1",
 		"@rsbuild/plugin-react": "^1.1.0",
+		"@rstest/adapter-rsbuild": "^0.2.2",
 		"@rstest/core": "^0.9.0",
 		"@tanstack/router-plugin": "^1.164.0",
+		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/react": "^16.3.2",
 		"@types/react": "^19.0.8",
 		"@types/react-dom": "^19.0.3",
 		"babel-plugin-react-compiler": "^1.0.0",
+		"happy-dom": "^20.8.3",
 		"typescript": "^5.6.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
 		"dev": "rsbuild dev --port 3000",
 		"build": "rsbuild build && tsc --noEmit",
 		"preview": "rsbuild preview",
+		"test": "rstest run",
+		"test:watch": "rstest watch",
 		"format": "biome format",
 		"lint": "biome lint",
 		"check": "biome check",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,12 +48,21 @@ importers:
       '@rsbuild/plugin-react':
         specifier: ^1.1.0
         version: 1.4.5(@rsbuild/core@1.7.3)
+      '@rstest/adapter-rsbuild':
+        specifier: ^0.2.2
+        version: 0.2.2(@rsbuild/core@1.7.3)(@rstest/core@0.9.0(core-js@3.47.0)(happy-dom@20.8.3))
       '@rstest/core':
         specifier: ^0.9.0
-        version: 0.9.0(core-js@3.47.0)
+        version: 0.9.0(core-js@3.47.0)(happy-dom@20.8.3)
       '@tanstack/router-plugin':
         specifier: ^1.164.0
         version: 1.164.0(@rsbuild/core@1.7.3)(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react':
         specifier: ^19.0.8
         version: 19.2.14
@@ -63,11 +72,17 @@ importers:
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
+      happy-dom:
+        specifier: ^20.8.3
+        version: 20.8.3
       typescript:
         specifier: ^5.6.2
         version: 5.9.3
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -207,6 +222,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -637,6 +656,12 @@ packages:
       webpack-hot-middleware:
         optional: true
 
+  '@rstest/adapter-rsbuild@0.2.2':
+    resolution: {integrity: sha512-Hv33JLQNN95wwCprGR51lDBqeUam9JR8gTdC0NvP5rcPmA/bFezAi1tERxnMci5FntGHgNicijZDfVhUm8v/Vg==}
+    peerDependencies:
+      '@rsbuild/core': '*'
+      '@rstest/core': '>=0.7.7'
+
   '@rstest/core@0.9.0':
     resolution: {integrity: sha512-YL0TlUUMDgSF3uZ9ZiaqJokST7x+Zlou/FsMDk62CfOuNGUt2jGEt+wH7iZ9h2PJCUmj/e47uAFtjpqY8NeoOA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -828,8 +853,34 @@ packages:
     resolution: {integrity: sha512-42WoRePf8v690qG8yGRe/YOh+oHni9vUaUUfoqlS91U2scd3a5rkLtVsc6b7z60w3RogH0I00vdrC5AaeiZ18w==}
     engines: {node: '>=20.19'}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -867,6 +918,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/node@25.3.5':
+    resolution: {integrity: sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -874,6 +928,12 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@xyflow/react@12.10.1':
     resolution: {integrity: sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==}
@@ -889,6 +949,14 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
@@ -896,6 +964,13 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -952,6 +1027,9 @@ packages:
   core-js@3.47.0:
     resolution: {integrity: sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -1002,6 +1080,10 @@ packages:
       supports-color:
         optional: true
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1010,12 +1092,22 @@ packages:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   electron-to-chromium@1.5.302:
     resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
 
   enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
@@ -1071,8 +1163,16 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  happy-dom@20.8.3:
+    resolution: {integrity: sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ==}
+    engines: {node: '>=20.0.0'}
+
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -1184,8 +1284,16 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1225,10 +1333,17 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
@@ -1245,6 +1360,10 @@ packages:
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reduce-configs@1.1.1:
     resolution: {integrity: sha512-EYtsVGAQarE8daT54cnaY1PIknF2VB78ug6Zre2rs36EsJfC40EG6hmTU2A2P1ZuXnKAt2KI0fzOGHcX7wzdPw==}
@@ -1284,6 +1403,10 @@ packages:
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
 
@@ -1322,6 +1445,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
@@ -1339,6 +1465,22 @@ packages:
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1362,6 +1504,8 @@ packages:
         optional: true
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -1549,6 +1693,8 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/runtime@7.28.6': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -1902,11 +2048,18 @@ snapshots:
       html-entities: 2.6.0
       react-refresh: 0.18.0
 
-  '@rstest/core@0.9.0(core-js@3.47.0)':
+  '@rstest/adapter-rsbuild@0.2.2(@rsbuild/core@1.7.3)(@rstest/core@0.9.0(core-js@3.47.0)(happy-dom@20.8.3))':
+    dependencies:
+      '@rsbuild/core': 1.7.3
+      '@rstest/core': 0.9.0(core-js@3.47.0)(happy-dom@20.8.3)
+
+  '@rstest/core@0.9.0(core-js@3.47.0)(happy-dom@20.8.3)':
     dependencies:
       '@rsbuild/core': 2.0.0-beta.7(core-js@3.47.0)
       '@types/chai': 5.2.3
       tinypool: 2.1.0
+    optionalDependencies:
+      happy-dom: 20.8.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - core-js
@@ -2093,10 +2246,42 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.161.4': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -2147,6 +2332,10 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/node@25.3.5':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -2154,6 +2343,12 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.3.5
 
   '@xyflow/react@12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -2180,12 +2375,22 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
   ansis@4.2.0: {}
 
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   assertion-error@2.0.1: {}
 
@@ -2246,6 +2451,8 @@ snapshots:
 
   core-js@3.47.0: {}
 
+  css.escape@1.5.1: {}
+
   csstype@3.2.3: {}
 
   d3-color@3.1.0: {}
@@ -2288,9 +2495,15 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   diff@8.0.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   electron-to-chromium@1.5.302: {}
 
@@ -2298,6 +2511,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@7.0.1: {}
 
   error-stack-parser@2.1.4:
     dependencies:
@@ -2363,7 +2578,21 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  happy-dom@20.8.3:
+    dependencies:
+      '@types/node': 25.3.5
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   html-entities@2.6.0: {}
+
+  indent-string@4.0.0: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -2440,9 +2669,13 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  min-indent@1.0.1: {}
 
   ms@2.1.3: {}
 
@@ -2468,10 +2701,18 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-refresh@0.18.0: {}
 
@@ -2488,6 +2729,11 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reduce-configs@1.1.1: {}
 
@@ -2510,6 +2756,10 @@ snapshots:
   source-map@0.7.6: {}
 
   stackframe@1.3.4: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   tailwindcss@4.2.1: {}
 
@@ -2541,6 +2791,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@7.18.2: {}
+
   unplugin@2.3.11:
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -2559,6 +2811,10 @@ snapshots:
       react: 19.2.4
 
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-mimetype@3.0.0: {}
+
+  ws@8.19.0: {}
 
   yallist@3.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@rsbuild/plugin-react':
         specifier: ^1.1.0
         version: 1.4.5(@rsbuild/core@1.7.3)
+      '@rstest/core':
+        specifier: ^0.9.0
+        version: 0.9.0(core-js@3.47.0)
       '@tanstack/router-plugin':
         specifier: ^1.164.0
         version: 1.164.0(@rsbuild/core@1.7.3)(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -477,6 +480,16 @@ packages:
     engines: {node: '>=18.12.0'}
     hasBin: true
 
+  '@rsbuild/core@2.0.0-beta.7':
+    resolution: {integrity: sha512-LjcLaugWJj2Zvjaw9CVJiHOpo3aNyLUuk8tqzVa2TOhHPyfJZ3/NnqMi0NtI+vkCce456J1+BNSvtrWH1Z5/fg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-babel@1.1.1':
     resolution: {integrity: sha512-aPMYlBRfMDM/yahd5cb9Y13Bz5RaPrASQRF62VQNbOQ+EoNOJl3IjQRpiC1OQGZqPaGHV0JE/Wo8hgRLPDvx6g==}
     peerDependencies:
@@ -492,8 +505,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.0.0-beta.5':
+    resolution: {integrity: sha512-PWV/fItbDY9ySPub2YT+DynZLaXeODfzd24SMykUDCfk5U8P/4sK7+7MB8HEN9PeLiM8+iTjHN/XuXti5DzgZA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@1.7.6':
     resolution: {integrity: sha512-J2g6xk8ZS7uc024dNTGTHxoFzFovAZIRixUG7PiciLKTMP78svbSSWrmW6N8oAsAkzYfJWwQpVgWfFNRHvYxSw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.0.0-beta.5':
+    resolution: {integrity: sha512-RfaI0Tf+efGblR2mgqzjKzFxN/NwDqnKsV14YxiwLDxbHFFBy7qSrbeLN+E3xapEaw9x0uTnzcUQDHjekkgXIA==}
     cpu: [x64]
     os: [darwin]
 
@@ -502,8 +525,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rspack/binding-linux-arm64-gnu@2.0.0-beta.5':
+    resolution: {integrity: sha512-Ydbdzji/IFTjPbB5MioBvxsGCpt9uY5W7x9e9c0qadZ5i2wExWjgEoGp0ALiWKPvkNaQo5CAu/0MEwf3C+kf9g==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rspack/binding-linux-arm64-musl@1.7.6':
     resolution: {integrity: sha512-DfQXKiyPIl7i1yECHy4eAkSmlUzzsSAbOjgMuKn7pudsWf483jg0UUYutNgXSlBjc/QSUp7906Cg8oty9OfwPA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@2.0.0-beta.5':
+    resolution: {integrity: sha512-HG1rRjypO2ShKGDbLJA8fqr/DWayo+YbNL3H/aBcv+it02TD2j8j9N2jyKwNpjp4LoMboDtFLOiKjmsLTMf3lQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -512,8 +545,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-gnu@2.0.0-beta.5':
+    resolution: {integrity: sha512-R6KCdMwnSXgz8qLZROxpYwSmq7/sLuyvL52TrzCNkMUIl6crfbEfSUAFQGcxMdy6lq5qX8Xir67TzTGMs7fNhw==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-linux-x64-musl@1.7.6':
     resolution: {integrity: sha512-rEy6MHKob02t/77YNgr6dREyJ0e0tv1X6Xsg8Z5E7rPXead06zefUbfazj4RELYySWnM38ovZyJAkPx/gOn3VA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-musl@2.0.0-beta.5':
+    resolution: {integrity: sha512-McRRtUYjcbGgIrPEJ4doRAdVhg28Y4Y6Bx1FVnIYWvwvZPQvUPT2DHsCnYcnP4P5hp531Oa3ISFz0oU3w10FAA==}
     cpu: [x64]
     os: [linux]
 
@@ -521,8 +564,17 @@ packages:
     resolution: {integrity: sha512-YupOrz0daSG+YBbCIgpDgzfMM38YpChv+afZpaxx5Ml7xPeAZIIdgWmLHnQ2rts73N2M1NspAiBwV00Xx0N4Vg==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@2.0.0-beta.5':
+    resolution: {integrity: sha512-4CDqMjcm+d/eTBa35aIAodJnZvy7diYK5n16Dx4erYl+qFfLLSIb/OFP9r+1MFBzWWMRjLORuQUwOMFaGc4m2Q==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@1.7.6':
     resolution: {integrity: sha512-INj7aVXjBvlZ84kEhSK4kJ484ub0i+BzgnjDWOWM1K+eFYDZjLdAsQSS3fGGXwVc3qKbPIssFfnftATDMTEJHQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.0.0-beta.5':
+    resolution: {integrity: sha512-11RH36VV8rFfImqQ3DiAmYfzAxof3T6xUqjf9JZSJYIavH4R4iDBqLaCBCkuTtdZAUl/Ujv3ziKpQ/bm/mqV/A==}
     cpu: [arm64]
     os: [win32]
 
@@ -531,13 +583,26 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.0.0-beta.5':
+    resolution: {integrity: sha512-XPqt2o2gLmhhEtrG4FgJ8KVNkbJPgGOwbfn3iz5+XjKcmC0ZCvQ1muRIQrhwfNeKaReLoWScFkam5gGcbTK7Gw==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@1.7.6':
     resolution: {integrity: sha512-zeUxEc0ZaPpmaYlCeWcjSJUPuRRySiSHN23oJ2Xyw0jsQ01Qm4OScPdr0RhEOFuK/UE+ANyRtDo4zJsY52Hadw==}
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@2.0.0-beta.5':
+    resolution: {integrity: sha512-Tx9OsnK+GTArCA1dxGnY3EAxjGTr1WSOPs24d0JlFSMpc8AOoDXu5YojE21K6dXnYxBwwb1aVc+aRg3ipS27uQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@1.7.6':
     resolution: {integrity: sha512-/NrEcfo8Gx22hLGysanrV6gHMuqZSxToSci/3M4kzEQtF5cPjfOv5pqeLK/+B6cr56ul/OmE96cCdWcXeVnFjQ==}
+
+  '@rspack/binding@2.0.0-beta.5':
+    resolution: {integrity: sha512-gep96+L6yaul0nMUS3RD7w2GkHlx5tgoxvAQ7/zJvI3xrd4UaRY+pnAtfTAr7sBt+y7YQZKHIPvZvHS5omvouQ==}
 
   '@rspack/core@1.7.6':
     resolution: {integrity: sha512-Iax6UhrfZqJajA778c1d5DBFbSIqPOSrI34kpNIiNpWd8Jq7mFIa+Z60SQb5ZQDZuUxcCZikjz5BxinFjTkg7Q==}
@@ -545,6 +610,18 @@ packages:
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
     peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.0.0-beta.5':
+    resolution: {integrity: sha512-7qylDEpBxhuoByPjXvKWZYeWSze+mQ54SuU5X9L8EcIjY22rWe/NcmyVHBkbUt5XC1cKP+nrCZMp9eNCBq3/Bg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
       '@swc/helpers':
         optional: true
 
@@ -558,6 +635,19 @@ packages:
       webpack-hot-middleware: 2.x
     peerDependenciesMeta:
       webpack-hot-middleware:
+        optional: true
+
+  '@rstest/core@0.9.0':
+    resolution: {integrity: sha512-YL0TlUUMDgSF3uZ9ZiaqJokST7x+Zlou/FsMDk62CfOuNGUt2jGEt+wH7iZ9h2PJCUmj/e47uAFtjpqY8NeoOA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   '@swc/helpers@0.5.19':
@@ -753,6 +843,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
@@ -770,6 +863,9 @@ packages:
 
   '@types/d3-zoom@3.0.8':
     resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -800,6 +896,10 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
@@ -1200,6 +1300,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1657,6 +1761,15 @@ snapshots:
       core-js: 3.47.0
       jiti: 2.6.1
 
+  '@rsbuild/core@2.0.0-beta.7(core-js@3.47.0)':
+    dependencies:
+      '@rspack/core': 2.0.0-beta.5(@swc/helpers@0.5.19)
+      '@swc/helpers': 0.5.19
+    optionalDependencies:
+      core-js: 3.47.0
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
   '@rsbuild/plugin-babel@1.1.1(@rsbuild/core@1.7.3)':
     dependencies:
       '@babel/core': 7.29.0
@@ -1680,19 +1793,37 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.7.6':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.0.0-beta.5':
+    optional: true
+
   '@rspack/binding-darwin-x64@1.7.6':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.0.0-beta.5':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.7.6':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.0.0-beta.5':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@1.7.6':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.0.0-beta.5':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.7.6':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.0.0-beta.5':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@1.7.6':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.0.0-beta.5':
     optional: true
 
   '@rspack/binding-wasm32-wasi@1.7.6':
@@ -1700,13 +1831,27 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.0.0-beta.5':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.7
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@1.7.6':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.0.0-beta.5':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.7.6':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.0.0-beta.5':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@1.7.6':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.0-beta.5':
     optional: true
 
   '@rspack/binding@1.7.6':
@@ -1722,11 +1867,30 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.7.6
       '@rspack/binding-win32-x64-msvc': 1.7.6
 
+  '@rspack/binding@2.0.0-beta.5':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.0.0-beta.5
+      '@rspack/binding-darwin-x64': 2.0.0-beta.5
+      '@rspack/binding-linux-arm64-gnu': 2.0.0-beta.5
+      '@rspack/binding-linux-arm64-musl': 2.0.0-beta.5
+      '@rspack/binding-linux-x64-gnu': 2.0.0-beta.5
+      '@rspack/binding-linux-x64-musl': 2.0.0-beta.5
+      '@rspack/binding-wasm32-wasi': 2.0.0-beta.5
+      '@rspack/binding-win32-arm64-msvc': 2.0.0-beta.5
+      '@rspack/binding-win32-ia32-msvc': 2.0.0-beta.5
+      '@rspack/binding-win32-x64-msvc': 2.0.0-beta.5
+
   '@rspack/core@1.7.6(@swc/helpers@0.5.19)':
     dependencies:
       '@module-federation/runtime-tools': 0.22.0
       '@rspack/binding': 1.7.6
       '@rspack/lite-tapable': 1.1.0
+    optionalDependencies:
+      '@swc/helpers': 0.5.19
+
+  '@rspack/core@2.0.0-beta.5(@swc/helpers@0.5.19)':
+    dependencies:
+      '@rspack/binding': 2.0.0-beta.5
     optionalDependencies:
       '@swc/helpers': 0.5.19
 
@@ -1737,6 +1901,15 @@ snapshots:
       error-stack-parser: 2.1.4
       html-entities: 2.6.0
       react-refresh: 0.18.0
+
+  '@rstest/core@0.9.0(core-js@3.47.0)':
+    dependencies:
+      '@rsbuild/core': 2.0.0-beta.7(core-js@3.47.0)
+      '@types/chai': 5.2.3
+      tinypool: 2.1.0
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - core-js
 
   '@swc/helpers@0.5.19':
     dependencies:
@@ -1946,6 +2119,11 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/d3-color@3.1.3': {}
 
   '@types/d3-drag@3.0.7':
@@ -1966,6 +2144,8 @@ snapshots:
     dependencies:
       '@types/d3-interpolate': 3.0.4
       '@types/d3-selection': 3.0.11
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -2006,6 +2186,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  assertion-error@2.0.1: {}
 
   ast-types@0.16.1:
     dependencies:
@@ -2341,6 +2523,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@2.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:

--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -1,0 +1,8 @@
+import { withRsbuildConfig } from '@rstest/adapter-rsbuild';
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  extends: withRsbuildConfig(),
+  testEnvironment: 'happy-dom',
+  setupFiles: ['./rstest.setup.ts'],
+});

--- a/rstest.setup.ts
+++ b/rstest.setup.ts
@@ -1,0 +1,10 @@
+import { afterEach, expect } from '@rstest/core';
+import { cleanup } from '@testing-library/react';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(jestDomMatchers);
+
+// Cleanup after each test to prevent test pollution
+afterEach(() => {
+  cleanup();
+});

--- a/src/features/diagram/lib/__tests__/docking.test.ts
+++ b/src/features/diagram/lib/__tests__/docking.test.ts
@@ -36,7 +36,7 @@ import type {
 describe("docking(lib)", () => {
 	describe("createDockedNodeState : position 객체로 DockedNodeState 객체를 생성한다", () => {
 		it("position이 {x: 520, y: 144}이면 DockedNodeState로 {freePosition: {x:520, y:144}, dockedCell:{col:5, row:2}, lastValidDock:{col:5, row:2}}를 반환한다", () => {
-			expect(createDockedNodeState({ x: 520, y: 144 })).toEqual({
+			expect(createDockedNodeState({ x: 520, y: 144 }, 7)).toEqual({
 				freePosition: { x: 520, y: 144 },
 				dockedCell: { col: 5, row: 2 },
 				lastValidDock: { col: 5, row: 2 },
@@ -138,14 +138,12 @@ describe("docking(lib)", () => {
 	describe("isDockableCell : 셀이 현재 stage에서 도킹 가능한지 판정한다", () => {
 		const emptyOccupancy = (): GridOccupancy => ({
 			occupiedCellCount: 0,
-			conflictCellCount: 0,
-			cellToNodeIds: new Map(),
+			cellToNodeId: new Map(),
 		});
 
-		const occupancyOf = (entries: Record<string, string[]>): GridOccupancy => ({
+		const occupancyOf = (entries: Record<string, string>): GridOccupancy => ({
 			occupiedCellCount: Object.keys(entries).length,
-			conflictCellCount: 0,
-			cellToNodeIds: new Map(Object.entries(entries)),
+			cellToNodeId: new Map(Object.entries(entries)),
 		});
 		describe("stage 경계 검사", () => {
 			//경계 밖 판정은 occupancy 와 무관하게 false
@@ -173,11 +171,11 @@ describe("docking(lib)", () => {
 
 		describe("점유 검사", () => {
 			it("비어 있는 셀에 도킹하면 true", () => {
-				const occupancy = occupancyOf({ "0,0": ["node-a"], "0,1": ["node-b"] });
+				const occupancy = occupancyOf({ "0,0": "node-a", "0,1": "node-b" });
 				expect(isDockableCell({ col: 0, row: 2 }, occupancy, 4)).toEqual(true);
 			});
 			it("다른 노드가 점유한 셀에 도킹하면 false", () => {
-				const occupancy = occupancyOf({ "1,2": ["node-a"] });
+				const occupancy = occupancyOf({ "1,2": "node-a" });
 				expect(isDockableCell({ col: 1, row: 2 }, occupancy, 4)).toEqual(false);
 			});
 		});
@@ -185,7 +183,7 @@ describe("docking(lib)", () => {
 		describe("ignoreNodeId 예외", () => {
 			it("ignoreNodeId가 node-a이고 셀 {1,2}를 node-a만 점유 중이면 true를 반환한다", () => {
 				const occupancy = occupancyOf({
-					"1,2": ["node-a"],
+					"1,2": "node-a",
 				});
 
 				const result = isDockableCell(
@@ -200,7 +198,7 @@ describe("docking(lib)", () => {
 
 			it("ignoreNodeId가 node-a이고 셀 {1,2}를 node-b가 점유 중이면 false를 반환한다", () => {
 				const occupancy = occupancyOf({
-					"1,2": ["node-b"],
+					"1,2": "node-b",
 				});
 
 				const result = isDockableCell(

--- a/src/features/diagram/lib/__tests__/docking.test.ts
+++ b/src/features/diagram/lib/__tests__/docking.test.ts
@@ -139,11 +139,19 @@ describe("docking(lib)", () => {
 		const emptyOccupancy = (): GridOccupancy => ({
 			occupiedCellCount: 0,
 			cellToNodeId: new Map(),
+			conflictedCellKeys: new Set(),
 		});
 
 		const occupancyOf = (entries: Record<string, string>): GridOccupancy => ({
 			occupiedCellCount: Object.keys(entries).length,
 			cellToNodeId: new Map(Object.entries(entries)),
+			conflictedCellKeys: new Set(),
+		});
+
+		const conflictedOccupancy = (...keys: string[]): GridOccupancy => ({
+			occupiedCellCount: keys.length,
+			cellToNodeId: new Map(),
+			conflictedCellKeys: new Set(keys),
 		});
 		describe("stage 경계 검사", () => {
 			//경계 밖 판정은 occupancy 와 무관하게 false
@@ -178,6 +186,10 @@ describe("docking(lib)", () => {
 				const occupancy = occupancyOf({ "1,2": "node-a" });
 				expect(isDockableCell({ col: 1, row: 2 }, occupancy, 4)).toEqual(false);
 			});
+			it("충돌 상태인 셀에 도킹하면 false", () => {
+				const occupancy = conflictedOccupancy("1,2");
+				expect(isDockableCell({ col: 1, row: 2 }, occupancy, 4)).toEqual(false);
+			});
 		});
 
 		describe("ignoreNodeId 예외", () => {
@@ -200,6 +212,19 @@ describe("docking(lib)", () => {
 				const occupancy = occupancyOf({
 					"1,2": "node-b",
 				});
+
+				const result = isDockableCell(
+					{ col: 1, row: 2 },
+					occupancy,
+					4,
+					"node-a",
+				);
+
+				expect(result).toEqual(false);
+			});
+
+			it("ignoreNodeId가 있어도 충돌 상태인 셀은 false를 반환한다", () => {
+				const occupancy = conflictedOccupancy("1,2");
 
 				const result = isDockableCell(
 					{ col: 1, row: 2 },

--- a/src/features/diagram/lib/__tests__/docking.test.ts
+++ b/src/features/diagram/lib/__tests__/docking.test.ts
@@ -1,0 +1,217 @@
+/*
+@TODO:
+- applyFallback
+  - lastValidDock가 유효하면 last-valid-dock 전략을 사용한다.
+  - lastValidDock가 막혀 있으면 nearest-empty-cell 전략을 사용한다.
+  - stage 전체가 막혀 있으면 clamp 전략을 사용한다.
+  - nearest empty cell 탐색은 현재 위치와 가장 가까운 빈 셀을 고른다.
+  - ignoreNodeId를 주면 자기 셀을 fallback 후보로 인정한다.
+
+- resolveDropPosition
+  - stage 안의 빈 nearest cell이면 valid-dock / usedFallback false
+  - stage 밖 위치면 outside-stage + fallback
+  - nearest cell이 점유 중이면 occupied-cell + fallback
+  - fallback 결과의 strategy가 그대로 노출된다.
+  - ignoreNodeId를 주면 자기 자리 드롭은 valid-dock 처리된다.
+
+- clampDockPosition
+  - stage 밖 좌표를 stage 내부 좌표로 보정한다.
+  - 이미 유효한 좌표면 그대로 반환한다.
+*/
+
+import { describe, expect, it } from "@rstest/core";
+import {
+	createDockedNodeState,
+	isDockableCell,
+	transitionDockedNodeState,
+} from "../docking";
+import type {
+	DockedNodeState,
+	DockingEvent,
+	DragCancelEvent,
+	DragStopEvent,
+	GridOccupancy,
+} from "../type";
+
+describe("docking(lib)", () => {
+	describe("createDockedNodeState : position 객체로 DockedNodeState 객체를 생성한다", () => {
+		it("position이 {x: 520, y: 144}이면 DockedNodeState로 {freePosition: {x:520, y:144}, dockedCell:{col:5, row:2}, lastValidDock:{col:5, row:2}}를 반환한다", () => {
+			expect(createDockedNodeState({ x: 520, y: 144 })).toEqual({
+				freePosition: { x: 520, y: 144 },
+				dockedCell: { col: 5, row: 2 },
+				lastValidDock: { col: 5, row: 2 },
+			});
+		});
+	});
+	describe("transitionDockedNodeState : dockingEvent에 따라 nodeState를 갱신한다. ", () => {
+		const initialNodeState = (): DockedNodeState => ({
+			freePosition: { x: 0, y: 0 },
+			dockedCell: { col: 0, row: 0 },
+			lastValidDock: { col: 0, row: 0 },
+		});
+
+		it("dragStart event는 freePosition만 갱신한다", () => {
+			const nodeState = initialNodeState();
+			const dragStartEvent = {
+				type: "dragStart",
+				position: { x: 300, y: 0 },
+			} as DockingEvent;
+
+			expect(transitionDockedNodeState(nodeState, dragStartEvent)).toEqual({
+				freePosition: { x: 300, y: 0 },
+				dockedCell: { col: 0, row: 0 },
+				lastValidDock: { col: 0, row: 0 },
+			});
+		});
+		it("dragMove event는 freePosition만 갱신한다", () => {
+			const nodeState = initialNodeState();
+			const dragMoveEvent = {
+				type: "dragMove",
+				position: { x: 300, y: 0 },
+			} as DockingEvent;
+
+			expect(transitionDockedNodeState(nodeState, dragMoveEvent)).toEqual({
+				freePosition: { x: 300, y: 0 },
+				dockedCell: { col: 0, row: 0 },
+				lastValidDock: { col: 0, row: 0 },
+			});
+		});
+		it("dragStop event는 freePosition, dockedCell을 갱신한다. dockedCell이 null이 아니면 lastValidDock도 갱신한다 ", () => {
+			const nodeState = initialNodeState();
+			const dragStopEvent = {
+				type: "dragStop",
+				position: { x: 190, y: 190 },
+				dockedCell: { col: 2, row: 2 },
+			} as DragStopEvent;
+
+			expect(transitionDockedNodeState(nodeState, dragStopEvent)).toEqual({
+				freePosition: { x: 190, y: 190 },
+				dockedCell: { col: 2, row: 2 },
+				lastValidDock: { col: 2, row: 2 },
+			});
+		});
+		it("dragStop event에서 dockedCell이 null이라면 lastValidDock은 갱신하지 않는다. ", () => {
+			const nodeState = initialNodeState();
+			const dragStopEvent = {
+				type: "dragStop",
+				position: { x: -200, y: 190 },
+				dockedCell: null,
+			} as DragStopEvent;
+
+			expect(transitionDockedNodeState(nodeState, dragStopEvent)).toEqual({
+				freePosition: { x: -200, y: 190 },
+				dockedCell: null,
+				lastValidDock: { col: 0, row: 0 },
+			});
+		});
+		it("dragCancelEvent는 lastValidDock 기준 위치로 freePosition을 복구한다 ", () => {
+			const nodeState = {
+				freePosition: { x: 190, y: 190 },
+				dockedCell: { col: 0, row: 0 },
+				lastValidDock: { col: 0, row: 0 },
+			};
+			const dragCancelEvent = {
+				type: "dragCancel",
+			} as DragCancelEvent;
+
+			expect(transitionDockedNodeState(nodeState, dragCancelEvent)).toEqual(
+				initialNodeState(),
+			);
+		});
+		it("dragCancel은 lastValidDock가 없으면 dockedCell 기준 위치로 복구한다", () => {
+			const nodeState = {
+				freePosition: { x: 190, y: 190 },
+				dockedCell: { col: 0, row: 0 },
+				lastValidDock: null,
+			};
+			const dragCancelEvent = {
+				type: "dragCancel",
+			} as DragCancelEvent;
+
+			expect(transitionDockedNodeState(nodeState, dragCancelEvent)).toEqual({
+				freePosition: { x: 0, y: 0 },
+				dockedCell: { col: 0, row: 0 },
+				lastValidDock: null,
+			});
+		});
+	});
+	describe("isDockableCell : 셀이 현재 stage에서 도킹 가능한지 판정한다", () => {
+		const emptyOccupancy = (): GridOccupancy => ({
+			occupiedCellCount: 0,
+			conflictCellCount: 0,
+			cellToNodeIds: new Map(),
+		});
+
+		const occupancyOf = (entries: Record<string, string[]>): GridOccupancy => ({
+			occupiedCellCount: Object.keys(entries).length,
+			conflictCellCount: 0,
+			cellToNodeIds: new Map(Object.entries(entries)),
+		});
+		describe("stage 경계 검사", () => {
+			//경계 밖 판정은 occupancy 와 무관하게 false
+			it("stage 범위 안이면 true", () => {
+				expect(isDockableCell({ col: 3, row: 3 }, emptyOccupancy(), 4)).toEqual(
+					true,
+				);
+			});
+			it("col이 음수면 false", () => {
+				expect(
+					isDockableCell({ col: -1, row: 2 }, emptyOccupancy(), 4),
+				).toEqual(false);
+			});
+			it("row가 음수면 false", () => {
+				expect(
+					isDockableCell({ col: 2, row: -1 }, emptyOccupancy(), 4),
+				).toEqual(false);
+			});
+			it("stage 이상 col/row면 false", () => {
+				expect(isDockableCell({ col: 4, row: 2 }, emptyOccupancy(), 4)).toEqual(
+					false,
+				);
+			});
+		});
+
+		describe("점유 검사", () => {
+			it("비어 있는 셀에 도킹하면 true", () => {
+				const occupancy = occupancyOf({ "0,0": ["node-a"], "0,1": ["node-b"] });
+				expect(isDockableCell({ col: 0, row: 2 }, occupancy, 4)).toEqual(true);
+			});
+			it("다른 노드가 점유한 셀에 도킹하면 false", () => {
+				const occupancy = occupancyOf({ "1,2": ["node-a"] });
+				expect(isDockableCell({ col: 1, row: 2 }, occupancy, 4)).toEqual(false);
+			});
+		});
+
+		describe("ignoreNodeId 예외", () => {
+			it("ignoreNodeId가 node-a이고 셀 {1,2}를 node-a만 점유 중이면 true를 반환한다", () => {
+				const occupancy = occupancyOf({
+					"1,2": ["node-a"],
+				});
+
+				const result = isDockableCell(
+					{ col: 1, row: 2 },
+					occupancy,
+					4,
+					"node-a",
+				);
+
+				expect(result).toEqual(true);
+			});
+
+			it("ignoreNodeId가 node-a이고 셀 {1,2}를 node-b가 점유 중이면 false를 반환한다", () => {
+				const occupancy = occupancyOf({
+					"1,2": ["node-b"],
+				});
+
+				const result = isDockableCell(
+					{ col: 1, row: 2 },
+					occupancy,
+					4,
+					"node-a",
+				);
+
+				expect(result).toEqual(false);
+			});
+		});
+	});
+});

--- a/src/features/diagram/lib/__tests__/grid.test.ts
+++ b/src/features/diagram/lib/__tests__/grid.test.ts
@@ -6,7 +6,7 @@
 - [x] 경계 판정/보정 함수
   - isNodeCenterOutsideStage, clampPositionToStage, isCellCoordInsideMaxGrid
 - [ ] 집계 함수
-  - getGridOccupancy (occupiedCellCount, conflictCellCount, cellToNodeIds)
+  - getGridOccupancy (occupiedCellCount, cellToNodeId)
 */
 
 import { describe, expect, it } from "@rstest/core";
@@ -14,6 +14,7 @@ import {
 	cellCoordToPosition,
 	clampPositionToStage,
 	GRID_STAGES,
+	getGridOccupancy,
 	getNextStage,
 	getStagePixelSize,
 	isCellCoordInsideMaxGrid,
@@ -22,6 +23,7 @@ import {
 	positionToNearestCellCoord,
 	toCellKey,
 } from "../grid";
+import type { DiagramNode } from "../type";
 
 describe("grid(lib)", () => {
 	describe("getNextStage: 다음 stage 값을 얻기", () => {
@@ -52,11 +54,11 @@ describe("grid(lib)", () => {
 	});
 	describe("positionToNearestCellCoord : position 객체로 가장 가까운 cell의 cellCoord 객체 얻기", () => {
 		it("position이 {x: 0, y: 0}이면 가장 가까운 cell 좌표로 {col: 0, row: 0}을 반환한다", () => {
-			const cellCoord = positionToNearestCellCoord({ x: 0, y: 0 });
+			const cellCoord = positionToNearestCellCoord({ x: 0, y: 0 }, 4);
 			expect(cellCoord).toEqual({ col: 0, row: 0 });
 		});
 		it("position이 {x: 520, y: 144}이면 가장 가까운 cell 좌표로 {col: 5, row: 2}를 반환한다", () => {
-			const cellCoord = positionToNearestCellCoord({ x: 520, y: 144 });
+			const cellCoord = positionToNearestCellCoord({ x: 520, y: 144 }, 7);
 			expect(cellCoord).toEqual({ col: 5, row: 2 });
 		});
 	});
@@ -164,6 +166,62 @@ describe("grid(lib)", () => {
 		it("maxGridSize가 4이고 cell 좌표가 {col: 4, row: 3}이면 지정한 grid 범위를 벗어나므로 false를 반환한다", () => {
 			const isInside = isCellCoordInsideMaxGrid({ col: 4, row: 3 }, 4);
 			expect(isInside).toEqual(false);
+		});
+	});
+	describe("getGridOccupancy : 노드 목록의 셀 점유 현황을 계산한다", () => {
+		const createNode = (id: string, x: number, y: number): DiagramNode =>
+			({
+				id,
+				position: { x, y },
+				data: { label: id },
+				type: "default",
+			}) as DiagramNode;
+
+		it("서로 다른 셀에 있는 노드들을 cellToNodeId에 단일 값으로 기록한다", () => {
+			const occupancy = getGridOccupancy(
+				[
+					createNode("node-a", 0, 0),
+					createNode("node-b", NODE_SIZE, NODE_SIZE * 2),
+				],
+				4,
+			);
+
+			expect(occupancy.occupiedCellCount).toEqual(2);
+			expect(Array.from(occupancy.cellToNodeId.entries())).toEqual([
+				["0,0", "node-a"],
+				["1,2", "node-b"],
+			]);
+		});
+
+		it("같은 셀에 여러 노드가 오면 첫 점유 노드만 유지한다", () => {
+			const occupancy = getGridOccupancy(
+				[
+					createNode("node-a", 0, 0),
+					createNode("node-b", 10, 10),
+					createNode("node-c", 20, 20),
+				],
+				4,
+			);
+
+			expect(occupancy.occupiedCellCount).toEqual(1);
+			expect(Array.from(occupancy.cellToNodeId.entries())).toEqual([
+				["0,0", "node-a"],
+			]);
+		});
+
+		it("최대 grid 범위 밖 노드는 점유 집계에서 제외한다", () => {
+			const occupancy = getGridOccupancy(
+				[
+					createNode("node-a", 0, 0),
+					createNode("node-b", NODE_SIZE * 11, NODE_SIZE * 11),
+				],
+				4,
+			);
+
+			expect(occupancy.occupiedCellCount).toEqual(1);
+			expect(Array.from(occupancy.cellToNodeId.entries())).toEqual([
+				["0,0", "node-a"],
+			]);
 		});
 	});
 });

--- a/src/features/diagram/lib/__tests__/grid.test.ts
+++ b/src/features/diagram/lib/__tests__/grid.test.ts
@@ -1,14 +1,3 @@
-/*
-- [x] 기초/상수 함수
-  - getNextStage, getStagePixelSize, toCellKey
-- [x] 좌표 변환 함수
-  - positionToNearestCellCoord, cellCoordToPosition
-- [x] 경계 판정/보정 함수
-  - isNodeCenterOutsideStage, clampPositionToStage, isCellCoordInsideMaxGrid
-- [ ] 집계 함수
-  - getGridOccupancy (occupiedCellCount, cellToNodeId)
-*/
-
 import { describe, expect, it } from "@rstest/core";
 import {
 	cellCoordToPosition,
@@ -204,9 +193,8 @@ describe("grid(lib)", () => {
 			);
 
 			expect(occupancy.occupiedCellCount).toEqual(1);
-			expect(Array.from(occupancy.cellToNodeId.entries())).toEqual([
-				["0,0", "node-a"],
-			]);
+			expect(Array.from(occupancy.cellToNodeId.entries())).toEqual([]);
+			expect(Array.from(occupancy.conflictedCellKeys)).toEqual(["0,0"]);
 		});
 
 		it("최대 grid 범위 밖 노드는 점유 집계에서 제외한다", () => {
@@ -222,6 +210,24 @@ describe("grid(lib)", () => {
 			expect(Array.from(occupancy.cellToNodeId.entries())).toEqual([
 				["0,0", "node-a"],
 			]);
+			expect(Array.from(occupancy.conflictedCellKeys)).toEqual([]);
+		});
+
+		it("충돌이 없는 셀과 충돌 셀을 함께 집계한다", () => {
+			const occupancy = getGridOccupancy(
+				[
+					createNode("node-a", 0, 0),
+					createNode("node-b", NODE_SIZE, 0),
+					createNode("node-c", NODE_SIZE + 10, 10),
+				],
+				4,
+			);
+
+			expect(occupancy.occupiedCellCount).toEqual(2);
+			expect(Array.from(occupancy.cellToNodeId.entries())).toEqual([
+				["0,0", "node-a"],
+			]);
+			expect(Array.from(occupancy.conflictedCellKeys)).toEqual(["1,0"]);
 		});
 	});
 });

--- a/src/features/diagram/lib/__tests__/grid.test.ts
+++ b/src/features/diagram/lib/__tests__/grid.test.ts
@@ -1,0 +1,169 @@
+/*
+- [x] 기초/상수 함수
+  - getNextStage, getStagePixelSize, toCellKey
+- [x] 좌표 변환 함수
+  - positionToNearestCellCoord, cellCoordToPosition
+- [x] 경계 판정/보정 함수
+  - isNodeCenterOutsideStage, clampPositionToStage, isCellCoordInsideMaxGrid
+- [ ] 집계 함수
+  - getGridOccupancy (occupiedCellCount, conflictCellCount, cellToNodeIds)
+*/
+
+import { describe, expect, it } from "@rstest/core";
+import {
+	cellCoordToPosition,
+	clampPositionToStage,
+	GRID_STAGES,
+	getNextStage,
+	getStagePixelSize,
+	isCellCoordInsideMaxGrid,
+	isNodeCenterOutsideStage,
+	NODE_SIZE,
+	positionToNearestCellCoord,
+	toCellKey,
+} from "../grid";
+
+describe("grid(lib)", () => {
+	describe("getNextStage: 다음 stage 값을 얻기", () => {
+		it(`현재 stage가 ${GRID_STAGES[0]}이면 다음 stage로 ${GRID_STAGES[1]}을 반환한다`, () => {
+			const stage = getNextStage(GRID_STAGES[0]);
+			expect(stage).toEqual(GRID_STAGES[1]);
+		});
+		it(`현재 stage가 ${GRID_STAGES[1]}이면 다음 stage로 ${GRID_STAGES[2]}을 반환한다`, () => {
+			const stage = getNextStage(GRID_STAGES[1]);
+			expect(stage).toEqual(GRID_STAGES[2]);
+		});
+		it(`현재 stage가 ${GRID_STAGES[2]}이면 마지막 stage이므로 ${GRID_STAGES[2]}을 그대로 반환한다`, () => {
+			const stage = getNextStage(GRID_STAGES[2]);
+			expect(stage).toEqual(GRID_STAGES[2]);
+		});
+	});
+	describe("getStagePixelSize : stage 값으로 stage의 pixel 사이즈 얻기", () => {
+		it(`stage가 4이면 stage pixel size로 ${4 * NODE_SIZE}를 반환한다`, () => {
+			const pixelSize = getStagePixelSize(4);
+			expect(pixelSize).toEqual(4 * NODE_SIZE);
+		});
+	});
+	describe("toCellKey : cell 객체로 cell을 위한 key string 얻기", () => {
+		it("cell이 {col: 1, row: 2}이면 key string으로 '1,2'를 반환한다", () => {
+			const keyString = toCellKey({ col: 1, row: 2 });
+			expect(keyString).toEqual("1,2");
+		});
+	});
+	describe("positionToNearestCellCoord : position 객체로 가장 가까운 cell의 cellCoord 객체 얻기", () => {
+		it("position이 {x: 0, y: 0}이면 가장 가까운 cell 좌표로 {col: 0, row: 0}을 반환한다", () => {
+			const cellCoord = positionToNearestCellCoord({ x: 0, y: 0 });
+			expect(cellCoord).toEqual({ col: 0, row: 0 });
+		});
+		it("position이 {x: 520, y: 144}이면 가장 가까운 cell 좌표로 {col: 5, row: 2}를 반환한다", () => {
+			const cellCoord = positionToNearestCellCoord({ x: 520, y: 144 });
+			expect(cellCoord).toEqual({ col: 5, row: 2 });
+		});
+	});
+	describe("cellCoordToPosition : cellCoord 객체로 position 객체로 얻기 ", () => {
+		it("cellCoord가 {col: 0, row: 0}이면 position으로 {x: 0, y: 0}을 반환한다", () => {
+			const cellCoord = cellCoordToPosition({ col: 0, row: 0 });
+			expect(cellCoord).toEqual({ x: 0, y: 0 });
+		});
+		it(`cellCoord가 {col: 9, row: 9}이면 position으로 {x: ${9 * NODE_SIZE}, y: ${9 * NODE_SIZE}}를 반환한다`, () => {
+			const cellCoord = cellCoordToPosition({ col: 9, row: 9 });
+			expect(cellCoord).toEqual({ x: 9 * NODE_SIZE, y: 9 * NODE_SIZE });
+		});
+	});
+	describe("isNodeCenterOutsideStage : 주어진 node의 중심 position이 stage 밖에 있는지 검증 ", () => {
+		it("stage가 4이고 중심 position이 (0, 0)이면 stage 밖이 아니므로 false를 반환한다", () => {
+			const isPositionOutside = isNodeCenterOutsideStage({ x: 0, y: 0 }, 4);
+			expect(isPositionOutside).toEqual(false);
+		});
+		it("stage가 4이고 중심 position이 (-1, 0)이면 stage 밖이므로 true를 반환한다", () => {
+			const isPositionOutside = isNodeCenterOutsideStage({ x: -1, y: 0 }, 4);
+			expect(isPositionOutside).toEqual(true);
+		});
+		it(`stage가 4이고 중심 position이 (${NODE_SIZE * 3 + NODE_SIZE / 2}, ${NODE_SIZE * 3 + NODE_SIZE / 2})이면 경계 안이므로 false를 반환한다`, () => {
+			const isPositionOutside = isNodeCenterOutsideStage(
+				{ x: NODE_SIZE * 3 + NODE_SIZE / 2, y: NODE_SIZE * 3 + NODE_SIZE / 2 },
+				4,
+			);
+			expect(isPositionOutside).toEqual(false);
+		});
+		it(`stage가 4이고 중심 position이 (${NODE_SIZE * 3 + NODE_SIZE / 2 + 1}, ${NODE_SIZE * 3 + NODE_SIZE / 2})이면 경계를 벗어나므로 true를 반환한다`, () => {
+			const isPositionOutside = isNodeCenterOutsideStage(
+				{
+					x: NODE_SIZE * 3 + NODE_SIZE / 2 + 1,
+					y: NODE_SIZE * 3 + NODE_SIZE / 2,
+				},
+				4,
+			);
+			expect(isPositionOutside).toEqual(true);
+		});
+		it(`stage가 10이고 중심 position이 (${NODE_SIZE * 9 + NODE_SIZE / 2}, 0)이면 마지막 열 경계 안이므로 false를 반환한다`, () => {
+			const isPositionOutside = isNodeCenterOutsideStage(
+				{
+					x: NODE_SIZE * 9 + NODE_SIZE / 2,
+					y: 0,
+				},
+				10,
+			);
+			expect(isPositionOutside).toEqual(false);
+		});
+	});
+	describe("clampPositionToStage : position을 stage 범위 안으로 보정한다", () => {
+		it("stage가 4이고 position이 음수이면 x와 y를 0으로 보정한다", () => {
+			const clampedPosition = clampPositionToStage({ x: -10, y: -20 }, 4);
+			expect(clampedPosition).toEqual({ x: 0, y: 0 });
+		});
+		it("stage가 4이고 position이 stage 범위 안이면 원래 좌표를 그대로 반환한다", () => {
+			const clampedPosition = clampPositionToStage(
+				{ x: NODE_SIZE, y: NODE_SIZE * 2 },
+				4,
+			);
+			expect(clampedPosition).toEqual({ x: NODE_SIZE, y: NODE_SIZE * 2 });
+		});
+		it("stage가 4이고 position이 마지막 셀 내부에 있으면 마지막 셀의 좌상단 좌표로 보정한다", () => {
+			const clampedPosition = clampPositionToStage(
+				{ x: NODE_SIZE * 3 + 1, y: NODE_SIZE * 3 + 1 },
+				4,
+			);
+			expect(clampedPosition).toEqual({
+				x: NODE_SIZE * 3,
+				y: NODE_SIZE * 3,
+			});
+		});
+		it("stage가 4이고 position이 최대 범위를 초과하면 마지막 셀의 좌상단 좌표로 보정한다", () => {
+			const clampedPosition = clampPositionToStage(
+				{ x: NODE_SIZE * 10, y: NODE_SIZE * 5 },
+				4,
+			);
+			expect(clampedPosition).toEqual({
+				x: NODE_SIZE * 3,
+				y: NODE_SIZE * 3,
+			});
+		});
+	});
+	describe("isCellCoordInsideMaxGrid : cell 좌표가 최대 grid 범위 안에 있는지 검증한다", () => {
+		it("cell 좌표가 {col: 0, row: 0}이면 최대 grid 범위 안이므로 true를 반환한다", () => {
+			const isInside = isCellCoordInsideMaxGrid({ col: 0, row: 0 });
+			expect(isInside).toEqual(true);
+		});
+		it("cell 좌표가 {col: -1, row: 0}이면 최대 grid 범위를 벗어나므로 false를 반환한다", () => {
+			const isInside = isCellCoordInsideMaxGrid({ col: -1, row: 0 });
+			expect(isInside).toEqual(false);
+		});
+		it("cell 좌표가 마지막 유효 셀 {col: 9, row: 9}이면 최대 grid 범위 안이므로 true를 반환한다", () => {
+			const isInside = isCellCoordInsideMaxGrid({ col: 9, row: 9 });
+			expect(isInside).toEqual(true);
+		});
+		it("cell 좌표가 {col: 10, row: 9}이면 최대 grid 범위를 벗어나므로 false를 반환한다", () => {
+			const isInside = isCellCoordInsideMaxGrid({ col: 10, row: 9 });
+			expect(isInside).toEqual(false);
+		});
+		it("maxGridSize가 4이고 cell 좌표가 {col: 3, row: 3}이면 지정한 grid 범위 안이므로 true를 반환한다", () => {
+			const isInside = isCellCoordInsideMaxGrid({ col: 3, row: 3 }, 4);
+			expect(isInside).toEqual(true);
+		});
+		it("maxGridSize가 4이고 cell 좌표가 {col: 4, row: 3}이면 지정한 grid 범위를 벗어나므로 false를 반환한다", () => {
+			const isInside = isCellCoordInsideMaxGrid({ col: 4, row: 3 }, 4);
+			expect(isInside).toEqual(false);
+		});
+	});
+});

--- a/src/features/diagram/lib/docking.ts
+++ b/src/features/diagram/lib/docking.ts
@@ -63,6 +63,27 @@ export type DockingInput = {
 	lastValidDock: CellCoord | null;
 };
 
+function getNearestCellIndex(axis: number): number {
+	const biasedAxis = axis + NODE_SIZE / 2 - Number.EPSILON;
+	return Math.floor(biasedAxis / NODE_SIZE);
+}
+
+export function getNearestDockCell(
+	position: XYPosition,
+	stage: GridStage,
+): CellCoord | null {
+	const cell = {
+		col: getNearestCellIndex(position.x),
+		row: getNearestCellIndex(position.y),
+	};
+
+	if (cell.col < 0 || cell.row < 0 || cell.col >= stage || cell.row >= stage) {
+		return null;
+	}
+
+	return cell;
+}
+
 export function toDockPosition(cell: CellCoord): XYPosition {
 	return {
 		x: cell.col * NODE_SIZE,

--- a/src/features/diagram/lib/docking.ts
+++ b/src/features/diagram/lib/docking.ts
@@ -114,9 +114,12 @@ export function isDockableCell(
 		return false;
 	}
 
-	const occupantId = occupancy.cellToNodeId.get(`${cell.col},${cell.row}`);
-	console.log(occupancy);
-	// 이미 점유중인 cell이 없는 경우
+	const key = `${cell.col},${cell.row}`;
+	if (occupancy.conflictedCellKeys.has(key)) {
+		return false;
+	}
+
+	const occupantId = occupancy.cellToNodeId.get(key);
 	if (!occupantId) {
 		return true;
 	}

--- a/src/features/diagram/lib/docking.ts
+++ b/src/features/diagram/lib/docking.ts
@@ -1,6 +1,6 @@
 import {
-	clampPositionToStage,
 	type CellCoord,
+	clampPositionToStage,
 	type GridOccupancy,
 	type GridStage,
 	isNodeOutsideStage,
@@ -12,24 +12,6 @@ export type XYPosition = {
 	y: number;
 };
 
-export const SNAP_IN_DISTANCE = 40;
-export const SNAP_OUT_DISTANCE = 56;
-
-export const DROP_REASONS = {
-	validDock: "valid-dock",
-	outsideStage: "outside-stage",
-	occupiedCell: "occupied-cell",
-	noNearestCell: "no-nearest-cell",
-} as const;
-
-export type DropReason = (typeof DROP_REASONS)[keyof typeof DROP_REASONS];
-
-export const FALLBACK_STRATEGIES = {
-	lastValidDock: "last-valid-dock",
-	nearestEmptyCell: "nearest-empty-cell",
-	clamp: "clamp",
-} as const;
-
 export type FallbackStrategy =
 	(typeof FALLBACK_STRATEGIES)[keyof typeof FALLBACK_STRATEGIES];
 
@@ -39,12 +21,7 @@ export type DockedNodeState = {
 	lastValidDock: CellCoord | null;
 };
 
-export const DRAG_EVENT_TRANSITIONS = {
-	dragStart: "freePosition만 현재 좌표로 갱신하고 도킹 기준점은 유지한다.",
-	dragMove: "freePosition만 드래그 좌표로 갱신한다.",
-	dragStop: "최종 좌표와 확정 dockedCell을 반영하고, 유효한 dockedCell이면 lastValidDock도 갱신한다.",
-	cancel: "lastValidDock 또는 dockedCell 기준 위치로 freePosition을 복구한다.",
-} as const;
+export type DropReason = (typeof DROP_REASONS)[keyof typeof DROP_REASONS];
 
 export type DockingEvent =
 	| {
@@ -89,6 +66,31 @@ export type FallbackInput = DockingInput & {
 	reason: DropReason;
 };
 
+export const SNAP_IN_DISTANCE = 40;
+export const SNAP_OUT_DISTANCE = 56;
+
+// 디버깅 용도 상수들
+export const DROP_REASONS = {
+	validDock: "valid-dock",
+	outsideStage: "outside-stage",
+	occupiedCell: "occupied-cell",
+	noNearestCell: "no-nearest-cell",
+} as const;
+
+export const FALLBACK_STRATEGIES = {
+	lastValidDock: "last-valid-dock",
+	nearestEmptyCell: "nearest-empty-cell",
+	clamp: "clamp",
+} as const;
+
+export const DRAG_EVENT_TRANSITIONS = {
+	dragStart: "freePosition만 현재 좌표로 갱신하고 도킹 기준점은 유지한다.",
+	dragMove: "freePosition만 드래그 좌표로 갱신한다.",
+	dragStop:
+		"최종 좌표와 확정 dockedCell을 반영하고, 유효한 dockedCell이면 lastValidDock도 갱신한다.",
+	cancel: "lastValidDock 또는 dockedCell 기준 위치로 freePosition을 복구한다.",
+} as const;
+
 export function createDockedNodeState(
 	position: XYPosition,
 	stage: GridStage,
@@ -123,7 +125,9 @@ export function transitionDockedNodeState(
 			const anchorCell = state.lastValidDock ?? state.dockedCell;
 			return {
 				...state,
-				freePosition: anchorCell ? toDockPosition(anchorCell) : state.freePosition,
+				freePosition: anchorCell
+					? cellCoordToXYDockPosition(anchorCell)
+					: state.freePosition,
 			};
 		}
 	}
@@ -160,7 +164,8 @@ export function isDockableCell(
 		return false;
 	}
 
-	const occupantIds = occupancy.cellToNodeIds.get(`${cell.col},${cell.row}`) ?? [];
+	const occupantIds =
+		occupancy.cellToNodeIds.get(`${cell.col},${cell.row}`) ?? [];
 
 	if (!ignoreNodeId) {
 		return occupantIds.length === 0;
@@ -179,7 +184,9 @@ function getNearestEmptyCell(input: DockingInput): CellCoord | null {
 		for (let col = 0; col < input.stage; col += 1) {
 			const cell = { col, row };
 
-			if (!isDockableCell(cell, input.occupancy, input.stage, input.ignoreNodeId)) {
+			if (
+				!isDockableCell(cell, input.occupancy, input.stage, input.ignoreNodeId)
+			) {
 				continue;
 			}
 
@@ -209,7 +216,7 @@ export function applyFallback(input: FallbackInput): FallbackResult {
 		)
 	) {
 		return {
-			position: toDockPosition(input.lastValidDock),
+			position: cellCoordToXYDockPosition(input.lastValidDock),
 			strategy: FALLBACK_STRATEGIES.lastValidDock,
 			cell: input.lastValidDock,
 		};
@@ -218,7 +225,7 @@ export function applyFallback(input: FallbackInput): FallbackResult {
 	const nearestEmptyCell = getNearestEmptyCell(input);
 	if (nearestEmptyCell) {
 		return {
-			position: toDockPosition(nearestEmptyCell),
+			position: cellCoordToXYDockPosition(nearestEmptyCell),
 			strategy: FALLBACK_STRATEGIES.nearestEmptyCell,
 			cell: nearestEmptyCell,
 		};
@@ -262,7 +269,14 @@ export function resolveDropPosition(input: DockingInput): ResolveDropResult {
 		};
 	}
 
-	if (!isDockableCell(nearestCell, input.occupancy, input.stage, input.ignoreNodeId)) {
+	if (
+		!isDockableCell(
+			nearestCell,
+			input.occupancy,
+			input.stage,
+			input.ignoreNodeId,
+		)
+	) {
 		const fallback = applyFallback({
 			...input,
 			reason: DROP_REASONS.occupiedCell,
@@ -276,20 +290,23 @@ export function resolveDropPosition(input: DockingInput): ResolveDropResult {
 	}
 
 	return {
-		position: toDockPosition(nearestCell),
+		position: cellCoordToXYDockPosition(nearestCell),
 		cell: nearestCell,
 		reason: DROP_REASONS.validDock,
 		usedFallback: false,
 	};
 }
 
-export function toDockPosition(cell: CellCoord): XYPosition {
+export function cellCoordToXYDockPosition(cell: CellCoord): XYPosition {
 	return {
 		x: cell.col * NODE_SIZE,
 		y: cell.row * NODE_SIZE,
 	};
 }
 
-export function clampDockPosition(position: XYPosition, stage: GridStage): XYPosition {
+export function clampDockPosition(
+	position: XYPosition,
+	stage: GridStage,
+): XYPosition {
 	return clampPositionToStage(position, stage);
 }

--- a/src/features/diagram/lib/docking.ts
+++ b/src/features/diagram/lib/docking.ts
@@ -40,7 +40,8 @@ export const DRAG_EVENT_TRANSITIONS = {
 	dragMove: "freePosition만 드래그 좌표로 갱신한다.",
 	dragStop:
 		"최종 좌표와 확정 dockedCell을 반영하고, 유효한 dockedCell이면 lastValidDock도 갱신한다.",
-	cancel: "lastValidDock 또는 dockedCell 기준 위치로 freePosition을 복구한다.",
+	dragCancel:
+		"lastValidDock 또는 dockedCell 기준 위치로 freePosition을 복구한다.",
 } as const;
 
 export function createDockedNodeState(position: XYPosition): DockedNodeState {
@@ -70,7 +71,7 @@ export function transitionDockedNodeState(
 				dockedCell: event.dockedCell,
 				lastValidDock: event.dockedCell ?? state.lastValidDock,
 			};
-		case "cancel": {
+		case "dragCancel": {
 			const anchorCell = state.lastValidDock ?? state.dockedCell;
 			return {
 				...state,
@@ -82,6 +83,24 @@ export function transitionDockedNodeState(
 	}
 }
 
+/**
+ * 주어진 grid cell이 현재 stage 안에서 도킹 가능한지 판정한다.
+ *
+ * 판정 규칙은 다음과 같다.
+ * - `cell.col`, `cell.row`가 `0 <= index < stage` 범위를 벗어나면 `false`
+ * - 해당 셀에 점유한 노드가 없으면 `true`
+ * - `ignoreNodeId`가 없으면 점유 노드가 하나라도 있으면 `false`
+ * - `ignoreNodeId`가 있으면, 그 셀의 점유 노드가 모두 자기 자신(`ignoreNodeId`)일 때만 `true`
+ *
+ * 이 함수는 드래그 중인 노드가 "원래 자기 셀" 위에 다시 드롭되는 상황에서
+ * 자기 자신을 충돌로 오판하지 않도록 `ignoreNodeId`를 지원한다.
+ *
+ * @param cell 도킹 가능 여부를 검사할 대상 셀 좌표
+ * @param occupancy 현재 grid 점유 상태. `cellToNodeIds`에서 `"col,row"` 키를 사용한다.
+ * @param stage 현재 활성 grid stage 크기. 유효 셀 범위는 `0`부터 `stage - 1`까지다.
+ * @param ignoreNodeId 충돌 검사에서 제외할 노드 id. 보통 현재 드래그 중인 노드 id를 넘긴다.
+ * @returns 해당 셀이 현재 조건에서 도킹 가능하면 `true`, 아니면 `false`
+ */
 export function isDockableCell(
 	cell: CellCoord,
 	occupancy: GridOccupancy,
@@ -96,9 +115,10 @@ export function isDockableCell(
 		occupancy.cellToNodeIds.get(`${cell.col},${cell.row}`) ?? [];
 
 	if (!ignoreNodeId) {
+		// ignoreNodeId가 없는 경우 점유 중인 Node가 하나라도 있으면 이미 차 있는 셀이므로 false 반환
 		return occupantIds.length === 0;
 	}
-
+	// ignoreNodeId가 있으면, 그 셀을 점유한 모든 노드가 전부 그 id인지 검사
 	return occupantIds.every((nodeId) => nodeId === ignoreNodeId);
 }
 

--- a/src/features/diagram/lib/docking.ts
+++ b/src/features/diagram/lib/docking.ts
@@ -44,8 +44,11 @@ export const DRAG_EVENT_TRANSITIONS = {
 		"lastValidDock 또는 dockedCell 기준 위치로 freePosition을 복구한다.",
 } as const;
 
-export function createDockedNodeState(position: XYPosition): DockedNodeState {
-	const dockedCell = positionToNearestCellCoord(position);
+export function createDockedNodeState(
+	position: XYPosition,
+	stage: GridStage,
+): DockedNodeState {
+	const dockedCell = positionToNearestCellCoord(position, stage);
 
 	return {
 		freePosition: position,
@@ -89,14 +92,14 @@ export function transitionDockedNodeState(
  * 판정 규칙은 다음과 같다.
  * - `cell.col`, `cell.row`가 `0 <= index < stage` 범위를 벗어나면 `false`
  * - 해당 셀에 점유한 노드가 없으면 `true`
- * - `ignoreNodeId`가 없으면 점유 노드가 하나라도 있으면 `false`
- * - `ignoreNodeId`가 있으면, 그 셀의 점유 노드가 모두 자기 자신(`ignoreNodeId`)일 때만 `true`
+ * - `ignoreNodeId`가 없으면 다른 노드가 이미 점유 중인 셀이므로 `false`
+ * - `ignoreNodeId`가 있으면, 그 셀 점유자가 자기 자신(`ignoreNodeId`)일 때만 `true`
  *
  * 이 함수는 드래그 중인 노드가 "원래 자기 셀" 위에 다시 드롭되는 상황에서
  * 자기 자신을 충돌로 오판하지 않도록 `ignoreNodeId`를 지원한다.
  *
  * @param cell 도킹 가능 여부를 검사할 대상 셀 좌표
- * @param occupancy 현재 grid 점유 상태. `cellToNodeIds`에서 `"col,row"` 키를 사용한다.
+ * @param occupancy 현재 grid 점유 상태. `cellToNodeId`에서 `"col,row"` 키를 사용한다.
  * @param stage 현재 활성 grid stage 크기. 유효 셀 범위는 `0`부터 `stage - 1`까지다.
  * @param ignoreNodeId 충돌 검사에서 제외할 노드 id. 보통 현재 드래그 중인 노드 id를 넘긴다.
  * @returns 해당 셀이 현재 조건에서 도킹 가능하면 `true`, 아니면 `false`
@@ -111,19 +114,22 @@ export function isDockableCell(
 		return false;
 	}
 
-	const occupantIds =
-		occupancy.cellToNodeIds.get(`${cell.col},${cell.row}`) ?? [];
+	const occupantId = occupancy.cellToNodeId.get(`${cell.col},${cell.row}`);
+	console.log(occupancy);
+	// 이미 점유중인 cell이 없는 경우
+	if (!occupantId) {
+		return true;
+	}
 
 	if (!ignoreNodeId) {
-		// ignoreNodeId가 없는 경우 점유 중인 Node가 하나라도 있으면 이미 차 있는 셀이므로 false 반환
-		return occupantIds.length === 0;
+		return false;
 	}
-	// ignoreNodeId가 있으면, 그 셀을 점유한 모든 노드가 전부 그 id인지 검사
-	return occupantIds.every((nodeId) => nodeId === ignoreNodeId);
+
+	return occupantId === ignoreNodeId;
 }
 
 function getNearestEmptyCell(input: DockingInput): CellCoord | null {
-	const nearestCell = positionToNearestCellCoord(input.position);
+	const nearestCell = positionToNearestCellCoord(input.position, input.stage);
 	const preferredCell = nearestCell ?? input.lastValidDock;
 	let bestCell: CellCoord | null = null;
 	let bestDistance = Number.POSITIVE_INFINITY;
@@ -184,7 +190,7 @@ export function applyFallback(input: FallbackInput): FallbackResult {
 	return {
 		position: clampedPosition,
 		strategy: FALLBACK_STRATEGIES.clamp,
-		cell: positionToNearestCellCoord(clampedPosition),
+		cell: positionToNearestCellCoord(clampedPosition, input.stage),
 	};
 }
 
@@ -202,7 +208,7 @@ export function resolveDropPosition(input: DockingInput): ResolveDropResult {
 		};
 	}
 
-	const nearestCell = positionToNearestCellCoord(input.position);
+	const nearestCell = positionToNearestCellCoord(input.position, input.stage);
 
 	if (!nearestCell) {
 		const fallback = applyFallback({

--- a/src/features/diagram/lib/docking.ts
+++ b/src/features/diagram/lib/docking.ts
@@ -1,0 +1,75 @@
+import {
+	clampPositionToStage,
+	type CellCoord,
+	type GridOccupancy,
+	type GridStage,
+	NODE_SIZE,
+} from "./grid";
+
+export type XYPosition = {
+	x: number;
+	y: number;
+};
+
+export const SNAP_IN_DISTANCE = 40;
+export const SNAP_OUT_DISTANCE = 56;
+
+export const DROP_REASONS = {
+	validDock: "valid-dock",
+	outsideStage: "outside-stage",
+	occupiedCell: "occupied-cell",
+	noNearestCell: "no-nearest-cell",
+} as const;
+
+export type DropReason = (typeof DROP_REASONS)[keyof typeof DROP_REASONS];
+
+export const FALLBACK_STRATEGIES = {
+	lastValidDock: "last-valid-dock",
+	nearestEmptyCell: "nearest-empty-cell",
+	clamp: "clamp",
+} as const;
+
+export type FallbackStrategy =
+	(typeof FALLBACK_STRATEGIES)[keyof typeof FALLBACK_STRATEGIES];
+
+export type DockedNodeState = {
+	freePosition: XYPosition;
+	dockedCell: CellCoord | null;
+	lastValidDock: CellCoord | null;
+};
+
+export type DropResolutionBase = {
+	reason: DropReason;
+	usedFallback: boolean;
+};
+
+export type FallbackResult = {
+	position: XYPosition;
+	strategy: FallbackStrategy;
+	cell: CellCoord | null;
+};
+
+export type ResolveDropResult = DropResolutionBase & {
+	position: XYPosition;
+	cell: CellCoord | null;
+	strategy?: FallbackStrategy;
+};
+
+export type DockingInput = {
+	position: XYPosition;
+	stage: GridStage;
+	occupancy: GridOccupancy;
+	ignoreNodeId?: string;
+	lastValidDock: CellCoord | null;
+};
+
+export function toDockPosition(cell: CellCoord): XYPosition {
+	return {
+		x: cell.col * NODE_SIZE,
+		y: cell.row * NODE_SIZE,
+	};
+}
+
+export function clampDockPosition(position: XYPosition, stage: GridStage): XYPosition {
+	return clampPositionToStage(position, stage);
+}

--- a/src/features/diagram/lib/docking.ts
+++ b/src/features/diagram/lib/docking.ts
@@ -3,6 +3,7 @@ import {
 	type CellCoord,
 	type GridOccupancy,
 	type GridStage,
+	isNodeOutsideStage,
 	NODE_SIZE,
 } from "./grid";
 
@@ -168,6 +169,56 @@ export function applyFallback(input: FallbackInput): FallbackResult {
 		position: clampedPosition,
 		strategy: FALLBACK_STRATEGIES.clamp,
 		cell: getNearestDockCell(clampedPosition, input.stage),
+	};
+}
+
+export function resolveDropPosition(input: DockingInput): ResolveDropResult {
+	if (isNodeOutsideStage(input.position, input.stage)) {
+		const fallback = applyFallback({
+			...input,
+			reason: DROP_REASONS.outsideStage,
+		});
+
+		return {
+			...fallback,
+			reason: DROP_REASONS.outsideStage,
+			usedFallback: true,
+		};
+	}
+
+	const nearestCell = getNearestDockCell(input.position, input.stage);
+
+	if (!nearestCell) {
+		const fallback = applyFallback({
+			...input,
+			reason: DROP_REASONS.noNearestCell,
+		});
+
+		return {
+			...fallback,
+			reason: DROP_REASONS.noNearestCell,
+			usedFallback: true,
+		};
+	}
+
+	if (!isDockableCell(nearestCell, input.occupancy, input.stage, input.ignoreNodeId)) {
+		const fallback = applyFallback({
+			...input,
+			reason: DROP_REASONS.occupiedCell,
+		});
+
+		return {
+			...fallback,
+			reason: DROP_REASONS.occupiedCell,
+			usedFallback: true,
+		};
+	}
+
+	return {
+		position: toDockPosition(nearestCell),
+		cell: nearestCell,
+		reason: DROP_REASONS.validDock,
+		usedFallback: false,
 	};
 }
 

--- a/src/features/diagram/lib/docking.ts
+++ b/src/features/diagram/lib/docking.ts
@@ -1,70 +1,21 @@
 import {
-	type CellCoord,
+	cellCoordToPosition,
 	clampPositionToStage,
 	type GridOccupancy,
-	type GridStage,
 	isNodeOutsideStage,
 	NODE_SIZE,
 } from "./grid";
-
-export type XYPosition = {
-	x: number;
-	y: number;
-};
-
-export type FallbackStrategy =
-	(typeof FALLBACK_STRATEGIES)[keyof typeof FALLBACK_STRATEGIES];
-
-export type DockedNodeState = {
-	freePosition: XYPosition;
-	dockedCell: CellCoord | null;
-	lastValidDock: CellCoord | null;
-};
-
-export type DropReason = (typeof DROP_REASONS)[keyof typeof DROP_REASONS];
-
-export type DockingEvent =
-	| {
-			type: "dragStart" | "dragMove";
-			position: XYPosition;
-	  }
-	| {
-			type: "dragStop";
-			position: XYPosition;
-			dockedCell: CellCoord | null;
-	  }
-	| {
-			type: "cancel";
-	  };
-
-export type DropResolutionBase = {
-	reason: DropReason;
-	usedFallback: boolean;
-};
-
-export type FallbackResult = {
-	position: XYPosition;
-	strategy: FallbackStrategy;
-	cell: CellCoord | null;
-};
-
-export type ResolveDropResult = DropResolutionBase & {
-	position: XYPosition;
-	cell: CellCoord | null;
-	strategy?: FallbackStrategy;
-};
-
-export type DockingInput = {
-	position: XYPosition;
-	stage: GridStage;
-	occupancy: GridOccupancy;
-	ignoreNodeId?: string;
-	lastValidDock: CellCoord | null;
-};
-
-export type FallbackInput = DockingInput & {
-	reason: DropReason;
-};
+import type {
+	CellCoord,
+	DockedNodeState,
+	DockingEvent,
+	DockingInput,
+	FallbackInput,
+	FallbackResult,
+	GridStage,
+	ResolveDropResult,
+	XYPosition,
+} from "./type";
 
 export const SNAP_IN_DISTANCE = 40;
 export const SNAP_OUT_DISTANCE = 56;
@@ -126,7 +77,7 @@ export function transitionDockedNodeState(
 			return {
 				...state,
 				freePosition: anchorCell
-					? cellCoordToXYDockPosition(anchorCell)
+					? cellCoordToPosition(anchorCell)
 					: state.freePosition,
 			};
 		}
@@ -216,7 +167,7 @@ export function applyFallback(input: FallbackInput): FallbackResult {
 		)
 	) {
 		return {
-			position: cellCoordToXYDockPosition(input.lastValidDock),
+			position: cellCoordToPosition(input.lastValidDock),
 			strategy: FALLBACK_STRATEGIES.lastValidDock,
 			cell: input.lastValidDock,
 		};
@@ -225,7 +176,7 @@ export function applyFallback(input: FallbackInput): FallbackResult {
 	const nearestEmptyCell = getNearestEmptyCell(input);
 	if (nearestEmptyCell) {
 		return {
-			position: cellCoordToXYDockPosition(nearestEmptyCell),
+			position: cellCoordToPosition(nearestEmptyCell),
 			strategy: FALLBACK_STRATEGIES.nearestEmptyCell,
 			cell: nearestEmptyCell,
 		};
@@ -290,17 +241,10 @@ export function resolveDropPosition(input: DockingInput): ResolveDropResult {
 	}
 
 	return {
-		position: cellCoordToXYDockPosition(nearestCell),
+		position: cellCoordToPosition(nearestCell),
 		cell: nearestCell,
 		reason: DROP_REASONS.validDock,
 		usedFallback: false,
-	};
-}
-
-export function cellCoordToXYDockPosition(cell: CellCoord): XYPosition {
-	return {
-		x: cell.col * NODE_SIZE,
-		y: cell.row * NODE_SIZE,
 	};
 }
 

--- a/src/features/diagram/lib/docking.ts
+++ b/src/features/diagram/lib/docking.ts
@@ -84,6 +84,25 @@ export function getNearestDockCell(
 	return cell;
 }
 
+export function isDockableCell(
+	cell: CellCoord,
+	occupancy: GridOccupancy,
+	stage: GridStage,
+	ignoreNodeId?: string,
+): boolean {
+	if (cell.col < 0 || cell.row < 0 || cell.col >= stage || cell.row >= stage) {
+		return false;
+	}
+
+	const occupantIds = occupancy.cellToNodeIds.get(`${cell.col},${cell.row}`) ?? [];
+
+	if (!ignoreNodeId) {
+		return occupantIds.length === 0;
+	}
+
+	return occupantIds.every((nodeId) => nodeId === ignoreNodeId);
+}
+
 export function toDockPosition(cell: CellCoord): XYPosition {
 	return {
 		x: cell.col * NODE_SIZE,

--- a/src/features/diagram/lib/docking.ts
+++ b/src/features/diagram/lib/docking.ts
@@ -1,9 +1,9 @@
 import {
 	cellCoordToPosition,
 	clampPositionToStage,
-	type GridOccupancy,
-	isNodeOutsideStage,
+	isNodeCenterOutsideStage,
 	NODE_SIZE,
+	positionToNearestCellCoord,
 } from "./grid";
 import type {
 	CellCoord,
@@ -12,6 +12,7 @@ import type {
 	DockingInput,
 	FallbackInput,
 	FallbackResult,
+	GridOccupancy,
 	GridStage,
 	ResolveDropResult,
 	XYPosition,
@@ -42,11 +43,8 @@ export const DRAG_EVENT_TRANSITIONS = {
 	cancel: "lastValidDock 또는 dockedCell 기준 위치로 freePosition을 복구한다.",
 } as const;
 
-export function createDockedNodeState(
-	position: XYPosition,
-	stage: GridStage,
-): DockedNodeState {
-	const dockedCell = getNearestDockCell(position, stage);
+export function createDockedNodeState(position: XYPosition): DockedNodeState {
+	const dockedCell = positionToNearestCellCoord(position);
 
 	return {
 		freePosition: position,
@@ -84,27 +82,6 @@ export function transitionDockedNodeState(
 	}
 }
 
-function getNearestCellIndex(axis: number): number {
-	const biasedAxis = axis + NODE_SIZE / 2 - Number.EPSILON;
-	return Math.floor(biasedAxis / NODE_SIZE);
-}
-
-export function getNearestDockCell(
-	position: XYPosition,
-	stage: GridStage,
-): CellCoord | null {
-	const cell = {
-		col: getNearestCellIndex(position.x),
-		row: getNearestCellIndex(position.y),
-	};
-
-	if (cell.col < 0 || cell.row < 0 || cell.col >= stage || cell.row >= stage) {
-		return null;
-	}
-
-	return cell;
-}
-
 export function isDockableCell(
 	cell: CellCoord,
 	occupancy: GridOccupancy,
@@ -126,7 +103,7 @@ export function isDockableCell(
 }
 
 function getNearestEmptyCell(input: DockingInput): CellCoord | null {
-	const nearestCell = getNearestDockCell(input.position, input.stage);
+	const nearestCell = positionToNearestCellCoord(input.position);
 	const preferredCell = nearestCell ?? input.lastValidDock;
 	let bestCell: CellCoord | null = null;
 	let bestDistance = Number.POSITIVE_INFINITY;
@@ -187,12 +164,12 @@ export function applyFallback(input: FallbackInput): FallbackResult {
 	return {
 		position: clampedPosition,
 		strategy: FALLBACK_STRATEGIES.clamp,
-		cell: getNearestDockCell(clampedPosition, input.stage),
+		cell: positionToNearestCellCoord(clampedPosition),
 	};
 }
 
 export function resolveDropPosition(input: DockingInput): ResolveDropResult {
-	if (isNodeOutsideStage(input.position, input.stage)) {
+	if (isNodeCenterOutsideStage(input.position, input.stage)) {
 		const fallback = applyFallback({
 			...input,
 			reason: DROP_REASONS.outsideStage,
@@ -205,7 +182,7 @@ export function resolveDropPosition(input: DockingInput): ResolveDropResult {
 		};
 	}
 
-	const nearestCell = getNearestDockCell(input.position, input.stage);
+	const nearestCell = positionToNearestCellCoord(input.position);
 
 	if (!nearestCell) {
 		const fallback = applyFallback({

--- a/src/features/diagram/lib/docking.ts
+++ b/src/features/diagram/lib/docking.ts
@@ -63,6 +63,10 @@ export type DockingInput = {
 	lastValidDock: CellCoord | null;
 };
 
+export type FallbackInput = DockingInput & {
+	reason: DropReason;
+};
+
 function getNearestCellIndex(axis: number): number {
 	const biasedAxis = axis + NODE_SIZE / 2 - Number.EPSILON;
 	return Math.floor(biasedAxis / NODE_SIZE);
@@ -101,6 +105,70 @@ export function isDockableCell(
 	}
 
 	return occupantIds.every((nodeId) => nodeId === ignoreNodeId);
+}
+
+function getNearestEmptyCell(input: DockingInput): CellCoord | null {
+	const nearestCell = getNearestDockCell(input.position, input.stage);
+	const preferredCell = nearestCell ?? input.lastValidDock;
+	let bestCell: CellCoord | null = null;
+	let bestDistance = Number.POSITIVE_INFINITY;
+
+	for (let row = 0; row < input.stage; row += 1) {
+		for (let col = 0; col < input.stage; col += 1) {
+			const cell = { col, row };
+
+			if (!isDockableCell(cell, input.occupancy, input.stage, input.ignoreNodeId)) {
+				continue;
+			}
+
+			const cellDistance = preferredCell
+				? Math.abs(preferredCell.col - col) + Math.abs(preferredCell.row - row)
+				: Math.abs(input.position.x - col * NODE_SIZE) +
+					Math.abs(input.position.y - row * NODE_SIZE);
+
+			if (cellDistance < bestDistance) {
+				bestCell = cell;
+				bestDistance = cellDistance;
+			}
+		}
+	}
+
+	return bestCell;
+}
+
+export function applyFallback(input: FallbackInput): FallbackResult {
+	if (
+		input.lastValidDock &&
+		isDockableCell(
+			input.lastValidDock,
+			input.occupancy,
+			input.stage,
+			input.ignoreNodeId,
+		)
+	) {
+		return {
+			position: toDockPosition(input.lastValidDock),
+			strategy: FALLBACK_STRATEGIES.lastValidDock,
+			cell: input.lastValidDock,
+		};
+	}
+
+	const nearestEmptyCell = getNearestEmptyCell(input);
+	if (nearestEmptyCell) {
+		return {
+			position: toDockPosition(nearestEmptyCell),
+			strategy: FALLBACK_STRATEGIES.nearestEmptyCell,
+			cell: nearestEmptyCell,
+		};
+	}
+
+	const clampedPosition = clampDockPosition(input.position, input.stage);
+
+	return {
+		position: clampedPosition,
+		strategy: FALLBACK_STRATEGIES.clamp,
+		cell: getNearestDockCell(clampedPosition, input.stage),
+	};
 }
 
 export function toDockPosition(cell: CellCoord): XYPosition {

--- a/src/features/diagram/lib/docking.ts
+++ b/src/features/diagram/lib/docking.ts
@@ -39,6 +39,27 @@ export type DockedNodeState = {
 	lastValidDock: CellCoord | null;
 };
 
+export const DRAG_EVENT_TRANSITIONS = {
+	dragStart: "freePosition만 현재 좌표로 갱신하고 도킹 기준점은 유지한다.",
+	dragMove: "freePosition만 드래그 좌표로 갱신한다.",
+	dragStop: "최종 좌표와 확정 dockedCell을 반영하고, 유효한 dockedCell이면 lastValidDock도 갱신한다.",
+	cancel: "lastValidDock 또는 dockedCell 기준 위치로 freePosition을 복구한다.",
+} as const;
+
+export type DockingEvent =
+	| {
+			type: "dragStart" | "dragMove";
+			position: XYPosition;
+	  }
+	| {
+			type: "dragStop";
+			position: XYPosition;
+			dockedCell: CellCoord | null;
+	  }
+	| {
+			type: "cancel";
+	  };
+
 export type DropResolutionBase = {
 	reason: DropReason;
 	usedFallback: boolean;
@@ -67,6 +88,46 @@ export type DockingInput = {
 export type FallbackInput = DockingInput & {
 	reason: DropReason;
 };
+
+export function createDockedNodeState(
+	position: XYPosition,
+	stage: GridStage,
+): DockedNodeState {
+	const dockedCell = getNearestDockCell(position, stage);
+
+	return {
+		freePosition: position,
+		dockedCell,
+		lastValidDock: dockedCell,
+	};
+}
+
+export function transitionDockedNodeState(
+	state: DockedNodeState,
+	event: DockingEvent,
+): DockedNodeState {
+	switch (event.type) {
+		case "dragStart":
+		case "dragMove":
+			return {
+				...state,
+				freePosition: event.position,
+			};
+		case "dragStop":
+			return {
+				freePosition: event.position,
+				dockedCell: event.dockedCell,
+				lastValidDock: event.dockedCell ?? state.lastValidDock,
+			};
+		case "cancel": {
+			const anchorCell = state.lastValidDock ?? state.dockedCell;
+			return {
+				...state,
+				freePosition: anchorCell ? toDockPosition(anchorCell) : state.freePosition,
+			};
+		}
+	}
+}
 
 function getNearestCellIndex(axis: number): number {
 	const biasedAxis = axis + NODE_SIZE / 2 - Number.EPSILON;

--- a/src/features/diagram/lib/grid.ts
+++ b/src/features/diagram/lib/grid.ts
@@ -1,4 +1,10 @@
-import type { CellCoord, DiagramNode, GridStage, XYPosition } from "./type";
+import type {
+	CellCoord,
+	DiagramNode,
+	GridOccupancy,
+	GridStage,
+	XYPosition,
+} from "./type";
 
 export const GRID_STAGES = [4, 7, 10] as const;
 export const MAX_GRID_STAGE: GridStage = GRID_STAGES[GRID_STAGES.length - 1];
@@ -16,26 +22,33 @@ export function getNextStage(currentStage: GridStage): GridStage {
 export function getStagePixelSize(stage: GridStage): number {
 	return stage * NODE_SIZE;
 }
+export function toCellKey(cell: CellCoord): string {
+	return `${cell.col},${cell.row}`;
+}
 
-export function positionToCellCoord(position: {
-	x: number;
-	y: number;
-}): CellCoord {
-	const centerX = position.x + NODE_SIZE / 2;
-	const centerY = position.y + NODE_SIZE / 2;
+/**
+ * 노드의 좌표{`x`,`y`}를 가장 가까운 그리드 셀 좌표로 변환합니다.
+ *
+ * XYPosition은 노드의 topLeftAxis를 나타냅니다.
+ * 노드의 좌상단 좌표를 그대로 쓰지 않고, 노드 중심점에 가깝게 보정한 뒤
+ * `Number.EPSILON`을 빼서 정확히 셀 경계에 놓인 경우 다음 셀로 밀리는 현상을 방지합니다.
+ * `NODE_SIZE`로 나누어 어느 셀에 가장 가깝게 위치하는지 계산합니다.
+ * @param position 노드의 {x, y} 좌표 객체
+ * @returns position에서 가장 가까운 셀의 좌표 {col, row} 객체
+ */
+export function positionToNearestCellCoord(position: XYPosition): CellCoord {
+	const biasedX = position.x + NODE_SIZE / 2 - Number.EPSILON;
+	const biasedY = position.y + NODE_SIZE / 2 - Number.EPSILON;
 
 	return {
-		col: Math.floor(centerX / NODE_SIZE),
-		row: Math.floor(centerY / NODE_SIZE),
+		col: Math.floor(biasedX / NODE_SIZE),
+		row: Math.floor(biasedY / NODE_SIZE),
 	};
 }
 export function cellCoordToPosition(cell: CellCoord): XYPosition {
-	return {
-		x: cell.col * NODE_SIZE,
-		y: cell.row * NODE_SIZE,
-	};
+	return { x: cell.col * NODE_SIZE, y: cell.row * NODE_SIZE };
 }
-export function isNodeOutsideStage(
+export function isNodeCenterOutsideStage(
 	position: { x: number; y: number },
 	stage: GridStage,
 ): boolean {
@@ -44,8 +57,8 @@ export function isNodeOutsideStage(
 	return (
 		position.x < 0 ||
 		position.y < 0 ||
-		position.x + NODE_SIZE > stageSize ||
-		position.y + NODE_SIZE > stageSize
+		position.x + NODE_SIZE / 2 > stageSize ||
+		position.y + NODE_SIZE / 2 > stageSize
 	);
 }
 
@@ -62,11 +75,7 @@ export function clampPositionToStage(
 	};
 }
 
-export function toCellKey(cell: CellCoord): string {
-	return `${cell.col},${cell.row}`;
-}
-
-function isCellInsideMaxGrid(
+export function isCellCoordInsideMaxGrid(
 	cell: CellCoord,
 	maxGridSize = MAX_GRID_STAGE,
 ): boolean {
@@ -78,32 +87,26 @@ function isCellInsideMaxGrid(
 	);
 }
 
-export function getOccupiedCells(nodes: DiagramNode[]): Set<string> {
-	const occupied = new Set<string>();
-
-	for (const node of nodes) {
-		const cell = positionToCellCoord(node.position);
-		if (!isCellInsideMaxGrid(cell)) {
-			continue;
-		}
-		occupied.add(toCellKey(cell));
-	}
-
-	return occupied;
-}
-
-export type GridOccupancy = {
-	occupiedCellCount: number;
-	conflictCellCount: number;
-	cellToNodeIds: Map<string, string[]>;
-};
-
+/**
+ * 주어진 노드 목록의 그리드 점유 현황을 상세하게 계산합니다.
+ *
+ * 각 노드의 `position`은 `positionToNearestCellCoord` 규칙으로 셀 좌표에 매핑되며,
+ * 최대 그리드 범위 `MAX_GRID_STAGE` 밖의 노드는 집계에서 제외됩니다.
+ *
+ * 반환값에는 다음 정보가 포함됩니다.
+ * - `occupiedCellCount`: 하나 이상의 노드가 차지한 고유 셀 수
+ * - `conflictCellCount`: 동일 셀에 두 개 이상 노드가 겹친 셀 수
+ * - `cellToNodeIds`: `"col,row"` 셀 키별 노드 ID 목록
+ *
+ * @param nodes 점유 현황을 계산할 다이어그램 노드 목록.
+ * @returns 셀 점유 수, 충돌 셀 수, 셀별 노드 ID 매핑을 포함한 그리드 점유 정보.
+ */
 export function getGridOccupancy(nodes: DiagramNode[]): GridOccupancy {
 	const cellToNodeIds = new Map<string, string[]>();
 
 	for (const node of nodes) {
-		const cell = positionToCellCoord(node.position);
-		if (!isCellInsideMaxGrid(cell)) {
+		const cell = positionToNearestCellCoord(node.position);
+		if (!isCellCoordInsideMaxGrid(cell)) {
 			continue;
 		}
 

--- a/src/features/diagram/lib/grid.ts
+++ b/src/features/diagram/lib/grid.ts
@@ -1,17 +1,4 @@
-import type { Node } from "@xyflow/react";
-
-export type CellCoord = {
-	col: number;
-	row: number;
-};
-
-export type DiagramNodeData = {
-	label: string;
-};
-
-export type DiagramNode = Node<DiagramNodeData>;
-
-export type GridStage = (typeof GRID_STAGES)[number];
+import type { CellCoord, DiagramNode, GridStage, XYPosition } from "./type";
 
 export const GRID_STAGES = [4, 7, 10] as const;
 export const MAX_GRID_STAGE: GridStage = GRID_STAGES[GRID_STAGES.length - 1];
@@ -30,7 +17,10 @@ export function getStagePixelSize(stage: GridStage): number {
 	return stage * NODE_SIZE;
 }
 
-export function toCellCoord(position: { x: number; y: number }): CellCoord {
+export function positionToCellCoord(position: {
+	x: number;
+	y: number;
+}): CellCoord {
 	const centerX = position.x + NODE_SIZE / 2;
 	const centerY = position.y + NODE_SIZE / 2;
 
@@ -39,7 +29,12 @@ export function toCellCoord(position: { x: number; y: number }): CellCoord {
 		row: Math.floor(centerY / NODE_SIZE),
 	};
 }
-
+export function cellCoordToPosition(cell: CellCoord): XYPosition {
+	return {
+		x: cell.col * NODE_SIZE,
+		y: cell.row * NODE_SIZE,
+	};
+}
 export function isNodeOutsideStage(
 	position: { x: number; y: number },
 	stage: GridStage,
@@ -87,7 +82,7 @@ export function getOccupiedCells(nodes: DiagramNode[]): Set<string> {
 	const occupied = new Set<string>();
 
 	for (const node of nodes) {
-		const cell = toCellCoord(node.position);
+		const cell = positionToCellCoord(node.position);
 		if (!isCellInsideMaxGrid(cell)) {
 			continue;
 		}
@@ -107,7 +102,7 @@ export function getGridOccupancy(nodes: DiagramNode[]): GridOccupancy {
 	const cellToNodeIds = new Map<string, string[]>();
 
 	for (const node of nodes) {
-		const cell = toCellCoord(node.position);
+		const cell = positionToCellCoord(node.position);
 		if (!isCellInsideMaxGrid(cell)) {
 			continue;
 		}

--- a/src/features/diagram/lib/grid.ts
+++ b/src/features/diagram/lib/grid.ts
@@ -39,7 +39,7 @@ export function toCellKey(cell: CellCoord): string {
 export function positionToNearestCellCoord(position: XYPosition): CellCoord {
 	const biasedX = position.x + NODE_SIZE / 2 - Number.EPSILON;
 	const biasedY = position.y + NODE_SIZE / 2 - Number.EPSILON;
-
+	//TODO: 경계 밖 값에 대한 null 처리
 	return {
 		col: Math.floor(biasedX / NODE_SIZE),
 		row: Math.floor(biasedY / NODE_SIZE),

--- a/src/features/diagram/lib/grid.ts
+++ b/src/features/diagram/lib/grid.ts
@@ -99,7 +99,8 @@ export function isCellCoordInsideMaxGrid(
  *
  * 반환값에는 다음 정보가 포함됩니다.
  * - `occupiedCellCount`: 하나 이상의 노드가 차지한 고유 셀 수
- * - `cellToNodeId`: `"col,row"` 셀 키별 대표 노드 ID
+ * - `cellToNodeId`: 충돌이 없는 `"col,row"` 셀 키별 유일 노드 ID
+ * - `conflictedCellKeys`: 둘 이상의 노드가 겹친 셀 키 집합
  *
  * @param nodes 점유 현황을 계산할 다이어그램 노드 목록.
  * @returns 셀 점유 수와 셀별 노드 ID 매핑을 포함한 그리드 점유 정보.
@@ -109,20 +110,26 @@ export function getGridOccupancy(
 	stage: GridStage,
 ): GridOccupancy {
 	const cellToNodeId = new Map<string, string>();
+	const conflictedCellKeys = new Set<string>();
 
 	for (const node of nodes) {
 		const cell = positionToNearestCellCoord(node.position, stage);
 		if (!cell) continue;
 
 		const key = toCellKey(cell);
-		const existing = cellToNodeId.get(key);
-		if (!existing) {
+		if (conflictedCellKeys.has(key)) continue;
+
+		if (cellToNodeId.has(key)) {
+			cellToNodeId.delete(key);
+			conflictedCellKeys.add(key);
+		} else {
 			cellToNodeId.set(key, node.id);
 		}
 	}
 
 	return {
-		occupiedCellCount: cellToNodeId.size,
+		occupiedCellCount: cellToNodeId.size + conflictedCellKeys.size,
 		cellToNodeId,
+		conflictedCellKeys,
 	};
 }

--- a/src/features/diagram/lib/grid.ts
+++ b/src/features/diagram/lib/grid.ts
@@ -25,29 +25,6 @@ export function getStagePixelSize(stage: GridStage): number {
 export function toCellKey(cell: CellCoord): string {
 	return `${cell.col},${cell.row}`;
 }
-
-/**
- * 노드의 좌표{`x`,`y`}를 가장 가까운 그리드 셀 좌표로 변환합니다.
- *
- * XYPosition은 노드의 topLeftAxis를 나타냅니다.
- * 노드의 좌상단 좌표를 그대로 쓰지 않고, 노드 중심점에 가깝게 보정한 뒤
- * `Number.EPSILON`을 빼서 정확히 셀 경계에 놓인 경우 다음 셀로 밀리는 현상을 방지합니다.
- * `NODE_SIZE`로 나누어 어느 셀에 가장 가깝게 위치하는지 계산합니다.
- * @param position 노드의 {x, y} 좌표 객체
- * @returns position에서 가장 가까운 셀의 좌표 {col, row} 객체
- */
-export function positionToNearestCellCoord(position: XYPosition): CellCoord {
-	const biasedX = position.x + NODE_SIZE / 2 - Number.EPSILON;
-	const biasedY = position.y + NODE_SIZE / 2 - Number.EPSILON;
-	//TODO: 경계 밖 값에 대한 null 처리
-	return {
-		col: Math.floor(biasedX / NODE_SIZE),
-		row: Math.floor(biasedY / NODE_SIZE),
-	};
-}
-export function cellCoordToPosition(cell: CellCoord): XYPosition {
-	return { x: cell.col * NODE_SIZE, y: cell.row * NODE_SIZE };
-}
 export function isNodeCenterOutsideStage(
 	position: { x: number; y: number },
 	stage: GridStage,
@@ -60,6 +37,33 @@ export function isNodeCenterOutsideStage(
 		position.x + NODE_SIZE / 2 > stageSize ||
 		position.y + NODE_SIZE / 2 > stageSize
 	);
+}
+/**
+ * 노드의 좌표{`x`,`y`}를 가장 가까운 그리드 셀 좌표로 변환합니다.
+ *
+ * XYPosition은 노드의 topLeftAxis를 나타냅니다.
+ * 노드의 좌상단 좌표를 그대로 쓰지 않고, 노드 중심점에 가깝게 보정한 뒤
+ * `Number.EPSILON`을 빼서 정확히 셀 경계에 놓인 경우 다음 셀로 밀리는 현상을 방지합니다.
+ * `NODE_SIZE`로 나누어 어느 셀에 가장 가깝게 위치하는지 계산합니다.
+ * @param position 노드의 {x, y} 좌표 객체
+ * @returns position에서 가장 가까운 셀의 좌표 {col, row} 객체
+ */
+export function positionToNearestCellCoord(
+	position: XYPosition,
+	stage: GridStage,
+): CellCoord | null {
+	if (isNodeCenterOutsideStage(position, stage)) return null;
+
+	const biasedX = position.x + NODE_SIZE / 2 - Number.EPSILON;
+	const biasedY = position.y + NODE_SIZE / 2 - Number.EPSILON;
+
+	return {
+		col: Math.floor(biasedX / NODE_SIZE),
+		row: Math.floor(biasedY / NODE_SIZE),
+	};
+}
+export function cellCoordToPosition(cell: CellCoord): XYPosition {
+	return { x: cell.col * NODE_SIZE, y: cell.row * NODE_SIZE };
 }
 
 export function clampPositionToStage(
@@ -95,40 +99,30 @@ export function isCellCoordInsideMaxGrid(
  *
  * 반환값에는 다음 정보가 포함됩니다.
  * - `occupiedCellCount`: 하나 이상의 노드가 차지한 고유 셀 수
- * - `conflictCellCount`: 동일 셀에 두 개 이상 노드가 겹친 셀 수
- * - `cellToNodeIds`: `"col,row"` 셀 키별 노드 ID 목록
+ * - `cellToNodeId`: `"col,row"` 셀 키별 대표 노드 ID
  *
  * @param nodes 점유 현황을 계산할 다이어그램 노드 목록.
- * @returns 셀 점유 수, 충돌 셀 수, 셀별 노드 ID 매핑을 포함한 그리드 점유 정보.
+ * @returns 셀 점유 수와 셀별 노드 ID 매핑을 포함한 그리드 점유 정보.
  */
-export function getGridOccupancy(nodes: DiagramNode[]): GridOccupancy {
-	const cellToNodeIds = new Map<string, string[]>();
+export function getGridOccupancy(
+	nodes: DiagramNode[],
+	stage: GridStage,
+): GridOccupancy {
+	const cellToNodeId = new Map<string, string>();
 
 	for (const node of nodes) {
-		const cell = positionToNearestCellCoord(node.position);
-		if (!isCellCoordInsideMaxGrid(cell)) {
-			continue;
-		}
+		const cell = positionToNearestCellCoord(node.position, stage);
+		if (!cell) continue;
 
 		const key = toCellKey(cell);
-		const existing = cellToNodeIds.get(key);
-		if (existing) {
-			existing.push(node.id);
-		} else {
-			cellToNodeIds.set(key, [node.id]);
-		}
-	}
-
-	let conflictCellCount = 0;
-	for (const nodeIds of cellToNodeIds.values()) {
-		if (nodeIds.length > 1) {
-			conflictCellCount += 1;
+		const existing = cellToNodeId.get(key);
+		if (!existing) {
+			cellToNodeId.set(key, node.id);
 		}
 	}
 
 	return {
-		occupiedCellCount: cellToNodeIds.size,
-		conflictCellCount,
-		cellToNodeIds,
+		occupiedCellCount: cellToNodeId.size,
+		cellToNodeId,
 	};
 }

--- a/src/features/diagram/lib/type.ts
+++ b/src/features/diagram/lib/type.ts
@@ -59,6 +59,7 @@ export type GridStage = (typeof GRID_STAGES)[number];
 export type GridOccupancy = {
 	occupiedCellCount: number;
 	cellToNodeId: Map<string, string>;
+	conflictedCellKeys: Set<string>;
 };
 
 export type FallbackStrategy =

--- a/src/features/diagram/lib/type.ts
+++ b/src/features/diagram/lib/type.ts
@@ -1,6 +1,6 @@
 import type { Node } from "@xyflow/react";
 import type { DROP_REASONS, FALLBACK_STRATEGIES } from "./docking";
-import type { GRID_STAGES, GridOccupancy } from "./grid";
+import type { GRID_STAGES } from "./grid";
 
 // Node 자유 이동은 XYPosition을 사용하고, drop시 grid snap을 위해 CellCoord 좌표계를 사용한다.
 export type CellCoord = {
@@ -55,6 +55,12 @@ export type DiagramNodeData = {
 export type DiagramNode = Node<DiagramNodeData>;
 
 export type GridStage = (typeof GRID_STAGES)[number];
+
+export type GridOccupancy = {
+	occupiedCellCount: number;
+	conflictCellCount: number;
+	cellToNodeIds: Map<string, string[]>;
+};
 
 export type FallbackStrategy =
 	(typeof FALLBACK_STRATEGIES)[keyof typeof FALLBACK_STRATEGIES];

--- a/src/features/diagram/lib/type.ts
+++ b/src/features/diagram/lib/type.ts
@@ -58,8 +58,7 @@ export type GridStage = (typeof GRID_STAGES)[number];
 
 export type GridOccupancy = {
 	occupiedCellCount: number;
-	conflictCellCount: number;
-	cellToNodeIds: Map<string, string[]>;
+	cellToNodeId: Map<string, string>;
 };
 
 export type FallbackStrategy =

--- a/src/features/diagram/lib/type.ts
+++ b/src/features/diagram/lib/type.ts
@@ -1,0 +1,89 @@
+import type { Node } from "@xyflow/react";
+import type { DROP_REASONS, FALLBACK_STRATEGIES } from "./docking";
+import type { GRID_STAGES, GridOccupancy } from "./grid";
+
+// Node 자유 이동은 XYPosition을 사용하고, drop시 grid snap을 위해 CellCoord 좌표계를 사용한다.
+export type CellCoord = {
+	col: number;
+	row: number;
+};
+export type XYPosition = {
+	x: number;
+	y: number;
+};
+
+/**
+ * 드래그 가능한 노드의 현재 배치 상태를 나타낸다.
+ *
+ * `freePosition`은 드래그 중 실제로 따라다니는 좌표이고,
+ * `dockedCell`은 현재 스냅되어 있다고 간주하는 그리드 셀이다.
+ * `lastValidDock`은 점유 충돌이나 범위 이탈이 발생했을 때
+ * 되돌아갈 수 있는 마지막 유효 도킹 위치를 보존한다.
+ */
+export type DockedNodeState = {
+	freePosition: XYPosition;
+	dockedCell: CellCoord | null;
+	lastValidDock: CellCoord | null;
+};
+
+/**
+ * 도킹 상태 머신에 입력되는 사용자 상호작용 이벤트다.
+ *
+ * - `dragStart`, `dragMove`: 자유 좌표만 갱신하고, 도킹 확정은 보류한다.
+ * - `dragStop`: 드롭 시점의 좌표와 확정된 `dockedCell`을 반영한다.
+ * - `cancel`: 드래그를 취소하고 마지막 유효 도킹 지점 또는 현재 도킹 지점으로 복구한다.
+ */
+
+export type DockingEvent =
+	| {
+			type: "dragStart" | "dragMove";
+			position: XYPosition;
+	  }
+	| {
+			type: "dragStop";
+			position: XYPosition;
+			dockedCell: CellCoord | null;
+	  }
+	| {
+			type: "cancel";
+	  };
+
+export type DiagramNodeData = {
+	label: string;
+};
+
+export type DiagramNode = Node<DiagramNodeData>;
+
+export type GridStage = (typeof GRID_STAGES)[number];
+
+export type FallbackStrategy =
+	(typeof FALLBACK_STRATEGIES)[keyof typeof FALLBACK_STRATEGIES];
+
+export type FallbackResult = {
+	position: XYPosition;
+	strategy: FallbackStrategy;
+	cell: CellCoord | null;
+};
+
+export type DockingInput = {
+	position: XYPosition;
+	stage: GridStage;
+	occupancy: GridOccupancy;
+	ignoreNodeId?: string;
+	lastValidDock: CellCoord | null;
+};
+
+export type DropReason = (typeof DROP_REASONS)[keyof typeof DROP_REASONS];
+
+export type DropResolutionBase = {
+	reason: DropReason;
+	usedFallback: boolean;
+};
+export type ResolveDropResult = DropResolutionBase & {
+	position: XYPosition;
+	cell: CellCoord | null;
+	strategy?: FallbackStrategy;
+};
+export type FallbackInput = DockingInput & {
+	reason: DropReason;
+};

--- a/src/features/diagram/lib/type.ts
+++ b/src/features/diagram/lib/type.ts
@@ -26,6 +26,19 @@ export type DockedNodeState = {
 	lastValidDock: CellCoord | null;
 };
 
+export interface DragStartEvent {
+	type: "dragStart" | "dragMove";
+	position: XYPosition;
+}
+export interface DragStopEvent {
+	type: "dragStop";
+	position: XYPosition;
+	dockedCell: CellCoord | null;
+}
+export interface DragCancelEvent {
+	type: "dragCancel";
+}
+
 /**
  * 도킹 상태 머신에 입력되는 사용자 상호작용 이벤트다.
  *
@@ -33,20 +46,7 @@ export type DockedNodeState = {
  * - `dragStop`: 드롭 시점의 좌표와 확정된 `dockedCell`을 반영한다.
  * - `cancel`: 드래그를 취소하고 마지막 유효 도킹 지점 또는 현재 도킹 지점으로 복구한다.
  */
-
-export type DockingEvent =
-	| {
-			type: "dragStart" | "dragMove";
-			position: XYPosition;
-	  }
-	| {
-			type: "dragStop";
-			position: XYPosition;
-			dockedCell: CellCoord | null;
-	  }
-	| {
-			type: "cancel";
-	  };
+export type DockingEvent = DragStartEvent | DragStopEvent | DragCancelEvent;
 
 export type DiagramNodeData = {
 	label: string;

--- a/src/features/diagram/ui/CanvasCore/CanvasCoreInner.tsx
+++ b/src/features/diagram/ui/CanvasCore/CanvasCoreInner.tsx
@@ -56,28 +56,23 @@ const initialNodes: DiagramNode[] = [
 		position: clampPositionToStage({ x: 0, y: 0 }, INITIAL_STAGE),
 		data: { label: "Node 1" },
 	},
-	{
-		id: "node-2",
-		type: "square",
-		position: clampPositionToStage({ x: 96, y: 0 }, INITIAL_STAGE),
-		data: { label: "Node 2" },
-	},
 ];
 export function CanvasCoreInner() {
 	const [nodes, setNodes, onNodesChange] =
 		useNodesState<DiagramNode>(initialNodes);
 	const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+	const [visibleStage, setVisibleStage] = useState<GridStage>(INITIAL_STAGE);
+
 	const [nodeDockingState, setNodeDockingState] = useState<
 		Record<string, DockedNodeState>
 	>(() =>
 		Object.fromEntries(
 			initialNodes.map((node) => [
 				node.id,
-				createDockedNodeState(node.position),
+				createDockedNodeState(node.position, visibleStage),
 			]),
 		),
 	);
-	const [visibleStage, setVisibleStage] = useState<GridStage>(INITIAL_STAGE);
 	const [showGuide, setShowGuide] = useState(false);
 	const nodeIdRef = useRef(initialNodes.length + 1);
 
@@ -88,7 +83,7 @@ export function CanvasCoreInner() {
 		[maxStagePixelSize, maxStagePixelSize],
 	];
 
-	const occupancy = getGridOccupancy(nodes);
+	const occupancy = getGridOccupancy(nodes, visibleStage);
 
 	const onConnect = (connection: Connection) => {
 		setEdges((currentEdges) =>
@@ -117,7 +112,8 @@ export function CanvasCoreInner() {
 		updater: (state: DockedNodeState) => DockedNodeState,
 	) => {
 		setNodeDockingState((currentState) => {
-			const baseState = currentState[nodeId] ?? createDockedNodeState(position);
+			const baseState =
+				currentState[nodeId] ?? createDockedNodeState(position, visibleStage);
 
 			return {
 				...currentState,
@@ -137,7 +133,6 @@ export function CanvasCoreInner() {
 	};
 
 	const handleNodeDrag = (_: MouseEvent, node: Node) => {
-		console.log(node.position);
 		updateNodeDockingState(node.id, node.position, (state) =>
 			transitionDockedNodeState(state, {
 				type: "dragMove",
@@ -154,7 +149,8 @@ export function CanvasCoreInner() {
 	const handleNodeDragStop = (_: MouseEvent, node: Node) => {
 		setVisibleStage((currentStage) => {
 			const currentDockingState =
-				nodeDockingState[node.id] ?? createDockedNodeState(node.position);
+				nodeDockingState[node.id] ??
+				createDockedNodeState(node.position, visibleStage);
 			const resolution = resolveDropPosition({
 				position: node.position,
 				stage: currentStage,
@@ -205,7 +201,7 @@ export function CanvasCoreInner() {
 		setNodes((currentNodes) => [...currentNodes, nextNode]);
 		setNodeDockingState((currentState) => ({
 			...currentState,
-			[id]: createDockedNodeState(nextNode.position),
+			[id]: createDockedNodeState(nextNode.position, visibleStage),
 		}));
 	};
 
@@ -222,8 +218,8 @@ export function CanvasCoreInner() {
 			</div>
 			<div className="absolute top-3 left-128 z-20 rounded border border-gray-300 bg-white/90 px-2 py-1 text-[11px] text-gray-700">
 				Stage: {visibleStage}x{visibleStage} | Occupied:{" "}
-				{occupancy.occupiedCellCount} | Conflict: {occupancy.conflictCellCount}{" "}
-				| Docking: {Object.keys(nodeDockingState).length}
+				{occupancy.occupiedCellCount} | Docking:{" "}
+				{Object.keys(nodeDockingState).length}
 			</div>
 			<div
 				className="relative bg-light-green"

--- a/src/features/diagram/ui/CanvasCore/CanvasCoreInner.tsx
+++ b/src/features/diagram/ui/CanvasCore/CanvasCoreInner.tsx
@@ -24,7 +24,7 @@ import {
 	getGridOccupancy,
 	getNextStage,
 	getStagePixelSize,
-	isNodeOutsideStage,
+	isNodeCenterOutsideStage,
 	MAX_GRID_STAGE,
 	NODE_SIZE,
 } from "../../lib/grid";
@@ -73,7 +73,7 @@ export function CanvasCoreInner() {
 		Object.fromEntries(
 			initialNodes.map((node) => [
 				node.id,
-				createDockedNodeState(node.position, INITIAL_STAGE),
+				createDockedNodeState(node.position),
 			]),
 		),
 	);
@@ -117,8 +117,7 @@ export function CanvasCoreInner() {
 		updater: (state: DockedNodeState) => DockedNodeState,
 	) => {
 		setNodeDockingState((currentState) => {
-			const baseState =
-				currentState[nodeId] ?? createDockedNodeState(position, visibleStage);
+			const baseState = currentState[nodeId] ?? createDockedNodeState(position);
 
 			return {
 				...currentState,
@@ -138,6 +137,7 @@ export function CanvasCoreInner() {
 	};
 
 	const handleNodeDrag = (_: MouseEvent, node: Node) => {
+		console.log(node.position);
 		updateNodeDockingState(node.id, node.position, (state) =>
 			transitionDockedNodeState(state, {
 				type: "dragMove",
@@ -145,7 +145,7 @@ export function CanvasCoreInner() {
 			}),
 		);
 		setVisibleStage((currentStage) =>
-			isNodeOutsideStage(node.position, currentStage)
+			isNodeCenterOutsideStage(node.position, currentStage)
 				? getNextStage(currentStage)
 				: currentStage,
 		);
@@ -154,8 +154,7 @@ export function CanvasCoreInner() {
 	const handleNodeDragStop = (_: MouseEvent, node: Node) => {
 		setVisibleStage((currentStage) => {
 			const currentDockingState =
-				nodeDockingState[node.id] ??
-				createDockedNodeState(node.position, currentStage);
+				nodeDockingState[node.id] ?? createDockedNodeState(node.position);
 			const resolution = resolveDropPosition({
 				position: node.position,
 				stage: currentStage,
@@ -206,7 +205,7 @@ export function CanvasCoreInner() {
 		setNodes((currentNodes) => [...currentNodes, nextNode]);
 		setNodeDockingState((currentState) => ({
 			...currentState,
-			[id]: createDockedNodeState(nextNode.position, visibleStage),
+			[id]: createDockedNodeState(nextNode.position),
 		}));
 	};
 

--- a/src/features/diagram/ui/CanvasCore/CanvasCoreInner.tsx
+++ b/src/features/diagram/ui/CanvasCore/CanvasCoreInner.tsx
@@ -15,15 +15,12 @@ import {
 import { type MouseEvent, useRef, useState } from "react";
 import {
 	createDockedNodeState,
-	type DockedNodeState,
 	resolveDropPosition,
 	transitionDockedNodeState,
 } from "../../lib/docking";
 import {
 	clampPositionToStage,
-	type DiagramNode,
 	GRID_STAGES,
-	type GridStage,
 	getGridOccupancy,
 	getNextStage,
 	getStagePixelSize,
@@ -31,6 +28,7 @@ import {
 	MAX_GRID_STAGE,
 	NODE_SIZE,
 } from "../../lib/grid";
+import type { DiagramNode, DockedNodeState, GridStage } from "../../lib/type";
 import GridGuideOverlay from "./GridGuideOverlay";
 import SquareNode from "./SquareNode";
 
@@ -155,7 +153,8 @@ export function CanvasCoreInner() {
 
 	const handleNodeDragStop = (_: MouseEvent, node: Node) => {
 		setVisibleStage((currentStage) => {
-			const currentDockingState = nodeDockingState[node.id] ??
+			const currentDockingState =
+				nodeDockingState[node.id] ??
 				createDockedNodeState(node.position, currentStage);
 			const resolution = resolveDropPosition({
 				position: node.position,
@@ -224,8 +223,8 @@ export function CanvasCoreInner() {
 			</div>
 			<div className="absolute top-3 left-128 z-20 rounded border border-gray-300 bg-white/90 px-2 py-1 text-[11px] text-gray-700">
 				Stage: {visibleStage}x{visibleStage} | Occupied:{" "}
-				{occupancy.occupiedCellCount} | Conflict: {occupancy.conflictCellCount} |
-				Docking: {Object.keys(nodeDockingState).length}
+				{occupancy.occupiedCellCount} | Conflict: {occupancy.conflictCellCount}{" "}
+				| Docking: {Object.keys(nodeDockingState).length}
 			</div>
 			<div
 				className="relative bg-light-green"

--- a/src/features/diagram/ui/CanvasCore/CanvasCoreInner.tsx
+++ b/src/features/diagram/ui/CanvasCore/CanvasCoreInner.tsx
@@ -14,6 +14,12 @@ import {
 
 import { type MouseEvent, useRef, useState } from "react";
 import {
+	createDockedNodeState,
+	getNearestDockCell,
+	type DockedNodeState,
+	transitionDockedNodeState,
+} from "../../lib/docking";
+import {
 	clampPositionToStage,
 	type DiagramNode,
 	GRID_STAGES,
@@ -63,6 +69,16 @@ export function CanvasCoreInner() {
 	const [nodes, setNodes, onNodesChange] =
 		useNodesState<DiagramNode>(initialNodes);
 	const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+	const [nodeDockingState, setNodeDockingState] = useState<
+		Record<string, DockedNodeState>
+	>(() =>
+		Object.fromEntries(
+			initialNodes.map((node) => [
+				node.id,
+				createDockedNodeState(node.position, INITIAL_STAGE),
+			]),
+		),
+	);
 	const [visibleStage, setVisibleStage] = useState<GridStage>(INITIAL_STAGE);
 	const [showGuide, setShowGuide] = useState(false);
 	const nodeIdRef = useRef(initialNodes.length + 1);
@@ -97,11 +113,38 @@ export function CanvasCoreInner() {
 		);
 	};
 
-	const handleNodeDragStart = () => {
+	const updateNodeDockingState = (
+		nodeId: string,
+		updater: (state: DockedNodeState) => DockedNodeState,
+	) => {
+		setNodeDockingState((currentState) => {
+			const baseState =
+				currentState[nodeId] ?? createDockedNodeState({ x: 0, y: 0 }, visibleStage);
+
+			return {
+				...currentState,
+				[nodeId]: updater(baseState),
+			};
+		});
+	};
+
+	const handleNodeDragStart = (_: MouseEvent, node: Node) => {
 		setShowGuide(true);
+		updateNodeDockingState(node.id, (state) =>
+			transitionDockedNodeState(state, {
+				type: "dragStart",
+				position: node.position,
+			}),
+		);
 	};
 
 	const handleNodeDrag = (_: MouseEvent, node: Node) => {
+		updateNodeDockingState(node.id, (state) =>
+			transitionDockedNodeState(state, {
+				type: "dragMove",
+				position: node.position,
+			}),
+		);
 		setVisibleStage((currentStage) =>
 			isNodeOutsideStage(node.position, currentStage)
 				? getNextStage(currentStage)
@@ -112,6 +155,8 @@ export function CanvasCoreInner() {
 	const handleNodeDragStop = (_: MouseEvent, node: Node) => {
 		setVisibleStage((currentStage) => {
 			const clamped = clampPositionToStage(node.position, currentStage);
+			const dockedCell = getNearestDockCell(clamped, currentStage);
+
 			if (clamped.x !== node.position.x || clamped.y !== node.position.y) {
 				setNodes((currentNodes) =>
 					currentNodes.map((currentNode) =>
@@ -121,6 +166,14 @@ export function CanvasCoreInner() {
 					),
 				);
 			}
+
+			updateNodeDockingState(node.id, (state) =>
+				transitionDockedNodeState(state, {
+					type: "dragStop",
+					position: clamped,
+					dockedCell,
+				}),
+			);
 			return currentStage; // No change to stage, just reading current value
 		});
 		setShowGuide(false);
@@ -146,6 +199,10 @@ export function CanvasCoreInner() {
 		};
 
 		setNodes((currentNodes) => [...currentNodes, nextNode]);
+		setNodeDockingState((currentState) => ({
+			...currentState,
+			[id]: createDockedNodeState(nextNode.position, visibleStage),
+		}));
 	};
 
 	return (
@@ -161,7 +218,8 @@ export function CanvasCoreInner() {
 			</div>
 			<div className="absolute top-3 left-128 z-20 rounded border border-gray-300 bg-white/90 px-2 py-1 text-[11px] text-gray-700">
 				Stage: {visibleStage}x{visibleStage} | Occupied:{" "}
-				{occupancy.occupiedCellCount} | Conflict: {occupancy.conflictCellCount}
+				{occupancy.occupiedCellCount} | Conflict: {occupancy.conflictCellCount} |
+				Docking: {Object.keys(nodeDockingState).length}
 			</div>
 			<div
 				className="relative bg-light-green"

--- a/src/features/diagram/ui/CanvasCore/CanvasCoreInner.tsx
+++ b/src/features/diagram/ui/CanvasCore/CanvasCoreInner.tsx
@@ -182,7 +182,7 @@ export function CanvasCoreInner() {
 					nodeTypes={nodeTypes}
 					nodeExtent={nodeExtent}
 					defaultViewport={LOCKED_VIEWPORT}
-					snapToGrid
+					// snapToGrid
 					snapGrid={[NODE_SIZE, NODE_SIZE]}
 					autoPanOnNodeDrag={false}
 					panOnDrag={false}

--- a/src/features/diagram/ui/CanvasCore/CanvasCoreInner.tsx
+++ b/src/features/diagram/ui/CanvasCore/CanvasCoreInner.tsx
@@ -15,8 +15,8 @@ import {
 import { type MouseEvent, useRef, useState } from "react";
 import {
 	createDockedNodeState,
-	getNearestDockCell,
 	type DockedNodeState,
+	resolveDropPosition,
 	transitionDockedNodeState,
 } from "../../lib/docking";
 import {
@@ -115,11 +115,12 @@ export function CanvasCoreInner() {
 
 	const updateNodeDockingState = (
 		nodeId: string,
+		position: { x: number; y: number },
 		updater: (state: DockedNodeState) => DockedNodeState,
 	) => {
 		setNodeDockingState((currentState) => {
 			const baseState =
-				currentState[nodeId] ?? createDockedNodeState({ x: 0, y: 0 }, visibleStage);
+				currentState[nodeId] ?? createDockedNodeState(position, visibleStage);
 
 			return {
 				...currentState,
@@ -130,7 +131,7 @@ export function CanvasCoreInner() {
 
 	const handleNodeDragStart = (_: MouseEvent, node: Node) => {
 		setShowGuide(true);
-		updateNodeDockingState(node.id, (state) =>
+		updateNodeDockingState(node.id, node.position, (state) =>
 			transitionDockedNodeState(state, {
 				type: "dragStart",
 				position: node.position,
@@ -139,7 +140,7 @@ export function CanvasCoreInner() {
 	};
 
 	const handleNodeDrag = (_: MouseEvent, node: Node) => {
-		updateNodeDockingState(node.id, (state) =>
+		updateNodeDockingState(node.id, node.position, (state) =>
 			transitionDockedNodeState(state, {
 				type: "dragMove",
 				position: node.position,
@@ -154,24 +155,29 @@ export function CanvasCoreInner() {
 
 	const handleNodeDragStop = (_: MouseEvent, node: Node) => {
 		setVisibleStage((currentStage) => {
-			const clamped = clampPositionToStage(node.position, currentStage);
-			const dockedCell = getNearestDockCell(clamped, currentStage);
+			const currentDockingState = nodeDockingState[node.id] ??
+				createDockedNodeState(node.position, currentStage);
+			const resolution = resolveDropPosition({
+				position: node.position,
+				stage: currentStage,
+				occupancy,
+				ignoreNodeId: node.id,
+				lastValidDock: currentDockingState.lastValidDock,
+			});
 
-			if (clamped.x !== node.position.x || clamped.y !== node.position.y) {
-				setNodes((currentNodes) =>
-					currentNodes.map((currentNode) =>
-						currentNode.id === node.id
-							? { ...currentNode, position: clamped }
-							: currentNode,
-					),
-				);
-			}
+			setNodes((currentNodes) =>
+				currentNodes.map((currentNode) =>
+					currentNode.id === node.id
+						? { ...currentNode, position: resolution.position }
+						: currentNode,
+				),
+			);
 
-			updateNodeDockingState(node.id, (state) =>
+			updateNodeDockingState(node.id, resolution.position, (state) =>
 				transitionDockedNodeState(state, {
 					type: "dragStop",
-					position: clamped,
-					dockedCell,
+					position: resolution.position,
+					dockedCell: resolution.cell,
 				}),
 			);
 			return currentStage; // No change to stage, just reading current value
@@ -240,7 +246,7 @@ export function CanvasCoreInner() {
 					nodeTypes={nodeTypes}
 					nodeExtent={nodeExtent}
 					defaultViewport={LOCKED_VIEWPORT}
-					// snapToGrid
+					snapToGrid={false}
 					snapGrid={[NODE_SIZE, NODE_SIZE]}
 					autoPanOnNodeDrag={false}
 					panOnDrag={false}

--- a/src/features/diagram/ui/CanvasCore/GridGuideOverlay.tsx
+++ b/src/features/diagram/ui/CanvasCore/GridGuideOverlay.tsx
@@ -1,5 +1,6 @@
 import { useId } from "react";
-import { type GridStage, getStagePixelSize, NODE_SIZE } from "../../lib/grid";
+import { getStagePixelSize, NODE_SIZE } from "../../lib/grid";
+import type { GridStage } from "../../lib/type";
 
 const CELL_MARGIN = 2;
 const CELL_STROKE_WIDTH = 1;

--- a/src/features/diagram/ui/CanvasCore/SquareNode.tsx
+++ b/src/features/diagram/ui/CanvasCore/SquareNode.tsx
@@ -1,5 +1,6 @@
 import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
-import { type DiagramNodeData, NODE_SIZE } from "../../lib/grid";
+import { NODE_SIZE } from "../../lib/grid";
+import type { DiagramNodeData } from "../../lib/type";
 
 export default function SquareNode({ data }: NodeProps<Node<DiagramNodeData>>) {
 	return (


### PR DESCRIPTION
## 배경
`Drag, Snap, Docking` 기본 기능 구현

- 도킹 규칙을 순수 함수로 분리해 재사용 가능하고 테스트 가능한 형태로 고정
- 드래그 중 자유 이동, 드롭 시점 스냅 확정이라는 상태 흐름을 명확히 분리

## 변경 요약
- 도킹 도메인 타입과 상수 추가
- nearest snap 계산 함수 추가
- 도킹 가능 셀 검증 함수 추가
- invalid drop용 fallback 체인 추가
- drop 단일 진입점 `resolveDropPosition` 추가
- 노드별 도킹 상태(`freePosition`, `dockedCell`, `lastValidDock`) 도입
- React Flow 드래그 종료 시점에만 스냅 확정되도록 연결

### 현재 단계에서 아직 다루지 않은 구현
- 스냅 프리뷰 표시
- 히스테리시스(`snapInDistance`, `snapOutDistance`) 적용
- 테스트 코드 추가

## 상세 설명
### 1. docking.ts
`src/features/diagram/lib/docking.ts`에 도킹 관련 타입과 상수를 추가했습니다.

주요 항목:
- `SNAP_IN_DISTANCE`, `SNAP_OUT_DISTANCE`
- `DROP_REASONS`
- `FALLBACK_STRATEGIES`
- `DockedNodeState`
```ts
export type DockedNodeState = {
	freePosition: XYPosition;
	dockedCell: CellCoord | null;
	lastValidDock: CellCoord | null;
};
```
- `DockingEvent`
```ts
export type DockingEvent =
	| {
			type: "dragStart" | "dragMove";
			position: XYPosition;
	  }
	| {
			type: "dragStop";
			position: XYPosition;
			dockedCell: CellCoord | null;
	  }
	| {
			type: "cancel";
	  };
```

### 2. nearest snap 계산 추가
`getNearestDockCell(position, stage)`를 추가했습니다.

이 함수는:
- 현재 좌표를 기준으로 가장 가까운 셀을 계산하고
- stage 범위를 벗어나면 `null`을 반환합니다.

동일 입력에 대해 동일 출력이 나오도록 tie-break를 고정해 이후 드롭 판정이 예측 가능하게 동작하도록 했습니다.

### 3. 도킹 가능 셀 검증 추가
`isDockableCell(cell, occupancy, stage, ignoreNodeId?)`를 추가했습니다.

이 함수는:
- 셀이 현재 stage 안에 있는지
- 다른 노드가 이미 점유 중인지

를 검사합니다.

`ignoreNodeId`를 받아 드래그 중인 자기 자신은 충돌로 간주하지 않도록 했습니다.

### 4. fallback 체인 추가
`applyFallback(input)`를 추가했습니다.

invalid drop 시 다음 우선순위로 대체 위치를 결정합니다.

1. `lastValidDock`
2. nearest empty cell
3. clamp position

반환값에는 최종 좌표뿐 아니라 어떤 전략이 선택됐는지 `strategy`도 포함시켜 이후 디버깅과 테스트에 활용할 수 있게 했습니다.

### 5. drop 해결기 추가
`resolveDropPosition(input)`를 추가해 드롭 처리의 단일 진입점을 만들었습니다.

처리 순서는 다음과 같습니다.

- stage 밖이면 fallback
- nearest cell이 없으면 fallback
- nearest cell이 occupied면 fallback
- 모두 통과하면 valid dock으로 확정

UI는 이 함수의 결과를 받아 반영만 하도록 했고, 도킹 정책은 도메인 함수 안에 모았습니다.

### 6. 노드별 도킹 상태 모델 도입
`CanvasCoreInner`에 노드별 도킹 상태를 추가했습니다.

관리하는 값:
- `freePosition`
- `dockedCell`
- `lastValidDock`

또한 `transitionDockedNodeState`를 통해 `dragStart`, `dragMove`, `dragStop`, `cancel` 전이 규칙을 한 곳에서 처리하도록 정리했습니다.

이 구조로 인해:
- 드래그 중 자유 좌표
- 최종 도킹 셀
- rollback 기준점

을 분리해서 다룰 수 있게 됐습니다.

### 7. 드롭 시점 스냅 연결
`onNodeDragStop`에서 `resolveDropPosition`을 호출하도록 연결했습니다.

동작은 다음과 같습니다.

- 드래그 중에는 노드가 자유롭게 이동
- 드롭 시점에만 nearest snap 계산
- invalid drop이면 fallback 결과 적용
- 최종 좌표를 React Flow 노드 상태와 도킹 상태에 동기화




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 개선된 드래그 앤 드롭 및 도킹 시스템 구현
  * 스냅 기능 및 위치 복구 정책 추가
  * 그리드 기반 위치 자동 조정 기능

* **Documentation**
  * Milestone 2 구현 계획 및 작업 분할 문서 추가
  * 로드맵 및 스코프 정의 업데이트

* **Chores**
  * 개발 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->